### PR TITLE
fix lazy loading on create paciente

### DIFF
--- a/src/main/java/com/kingg/api_vacunas_panama/persistence/repository/DireccionRepository.java
+++ b/src/main/java/com/kingg/api_vacunas_panama/persistence/repository/DireccionRepository.java
@@ -3,15 +3,16 @@ package com.kingg.api_vacunas_panama.persistence.repository;
 import com.kingg.api_vacunas_panama.persistence.entity.Direccion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface DireccionRepository extends JpaRepository<Direccion, UUID> {
 
-    Optional<Direccion> findDireccionByDireccionAndDistrito_Id(String direccion, int idDistrito);
+    Optional<List<Direccion>> findDireccionByDireccionAndDistrito_Id(String direccion, int idDistrito);
 
-    Optional<Direccion> findDireccionByDireccionContainingIgnoreCase(String direccion);
+    Optional<List<Direccion>> findDireccionByDireccionStartingWith(String direccion);
 
-    Optional<Direccion> findDireccionByDireccionAndDistrito_Nombre(String direccion, String distrito);
+    Optional<List<Direccion>> findDireccionByDireccionAndDistrito_Nombre(String direccion, String distrito);
 
 }

--- a/src/main/java/com/kingg/api_vacunas_panama/service/DireccionService.java
+++ b/src/main/java/com/kingg/api_vacunas_panama/service/DireccionService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 /**
@@ -54,6 +55,8 @@ public class DireccionService implements IDireccionService {
 
     Direccion getDireccionDefault() {
         var result = direccionRepository.findDireccionByDireccionAndDistrito_Id("Por registrar", 0).orElseThrow();
+        if (result.isEmpty())
+            throw new NoSuchElementException("La dirección por defecto no fue encontrada");
         return result.getFirst();
     }
 

--- a/src/main/java/com/kingg/api_vacunas_panama/service/PacienteService.java
+++ b/src/main/java/com/kingg/api_vacunas_panama/service/PacienteService.java
@@ -15,6 +15,7 @@ import com.kingg.api_vacunas_panama.web.dto.ViewPacienteVacunaEnfermedadDto;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -171,6 +172,10 @@ public class PacienteService implements IPacienteService {
                 .createdAt(pacienteDto.getCreatedAt() != null ? pacienteDto.getCreatedAt() : LocalDateTime.now(ZoneOffset.UTC))
                 .build();
         paciente = pacienteRepository.save(paciente);
+        Hibernate.initialize(paciente.getDireccion());
+        Hibernate.initialize(paciente.getDireccion().getDistrito());
+        Hibernate.initialize(paciente.getDireccion().getDistrito().getProvincia());
+        Hibernate.initialize(paciente.getUsuario());
         var result = mapper.toDto(paciente);
         apiContentResponse.addData("paciente", result);
         return apiContentResponse;


### PR DESCRIPTION
add Hibernate initialize relations of Paciente -> Dirección -> Distrito -> Provincia

fixed #4

## Resumen por Sourcery

Correcciones de errores:
- Solucionar el problema de carga diferida inicializando las relaciones de Hibernate para las entidades Paciente, Direccion, Distrito y Provincia.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix lazy loading issue by initializing Hibernate relations for Paciente, Direccion, Distrito, and Provincia entities.

</details>