### PR TITLE
build(kover): add plugin of coverage java and kotlin code

### DIFF
--- a/.idea/runConfigurations/api_vacunas_panama__koverXmlReport_.xml
+++ b/.idea/runConfigurations/api_vacunas_panama__koverXmlReport_.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="api-vacunas-panama [koverXmlReport]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="koverXmlReport" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -1,7 +1,7 @@
 
 # api-vacunas-panama
 ## Dependency License Report
-_2025-03-26 11:27:11 EST_
+_2025-03-26 23:03:10 EST_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.fasterxml` **Name:** `classmate` **Version:** `1.7.0`
@@ -239,254 +239,248 @@ _2025-03-26 11:27:11 EST_
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**44** **Group:** `org.mapstruct` **Name:** `mapstruct` **Version:** `1.6.3`
-> - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
-> - **POM Project URL**: [https://mapstruct.org/mapstruct/](https://mapstruct.org/mapstruct/)
-> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
-> - **Embedded license files**: [mapstruct-1.6.3.jar/META-INF/LICENSE.txt](build/reports/dependency-license/mapstruct-1.6.3.jar/META-INF/LICENSE.txt)
-
-**45** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.2.5`
+**44** **Group:** `org.springframework` **Name:** `spring-aop` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-aop-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-aop-6.2.5.jar/META-INF/license.txt)
     - [spring-aop-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-aop-6.2.5.jar/META-INF/notice.txt)
 
-**46** **Group:** `org.springframework` **Name:** `spring-aspects` **Version:** `6.2.5`
+**45** **Group:** `org.springframework` **Name:** `spring-aspects` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-aspects-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-aspects-6.2.5.jar/META-INF/license.txt)
     - [spring-aspects-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-aspects-6.2.5.jar/META-INF/notice.txt)
 
-**47** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.2.5`
+**46** **Group:** `org.springframework` **Name:** `spring-beans` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-beans-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-beans-6.2.5.jar/META-INF/license.txt)
     - [spring-beans-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-beans-6.2.5.jar/META-INF/notice.txt)
 
-**48** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.2.5`
+**47** **Group:** `org.springframework` **Name:** `spring-context` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-context-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-context-6.2.5.jar/META-INF/license.txt)
     - [spring-context-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-context-6.2.5.jar/META-INF/notice.txt)
 
-**49** **Group:** `org.springframework` **Name:** `spring-context-support` **Version:** `6.2.5`
+**48** **Group:** `org.springframework` **Name:** `spring-context-support` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-context-support-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-context-support-6.2.5.jar/META-INF/license.txt)
     - [spring-context-support-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-context-support-6.2.5.jar/META-INF/notice.txt)
 
-**50** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.2.5`
+**49** **Group:** `org.springframework` **Name:** `spring-core` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-core-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-core-6.2.5.jar/META-INF/license.txt)
     - [spring-core-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-core-6.2.5.jar/META-INF/notice.txt)
 
-**51** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.2.5`
+**50** **Group:** `org.springframework` **Name:** `spring-expression` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-expression-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-expression-6.2.5.jar/META-INF/license.txt)
     - [spring-expression-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-expression-6.2.5.jar/META-INF/notice.txt)
 
-**52** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.2.5`
+**51** **Group:** `org.springframework` **Name:** `spring-jcl` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-jcl-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-jcl-6.2.5.jar/META-INF/license.txt)
     - [spring-jcl-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-jcl-6.2.5.jar/META-INF/notice.txt)
 
-**53** **Group:** `org.springframework` **Name:** `spring-jdbc` **Version:** `6.2.5`
+**52** **Group:** `org.springframework` **Name:** `spring-jdbc` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-jdbc-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-jdbc-6.2.5.jar/META-INF/license.txt)
     - [spring-jdbc-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-jdbc-6.2.5.jar/META-INF/notice.txt)
 
-**54** **Group:** `org.springframework` **Name:** `spring-orm` **Version:** `6.2.5`
+**53** **Group:** `org.springframework` **Name:** `spring-orm` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-orm-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-orm-6.2.5.jar/META-INF/license.txt)
     - [spring-orm-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-orm-6.2.5.jar/META-INF/notice.txt)
 
-**55** **Group:** `org.springframework` **Name:** `spring-oxm` **Version:** `6.2.5`
+**54** **Group:** `org.springframework` **Name:** `spring-oxm` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-oxm-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-oxm-6.2.5.jar/META-INF/license.txt)
     - [spring-oxm-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-oxm-6.2.5.jar/META-INF/notice.txt)
 
-**56** **Group:** `org.springframework` **Name:** `spring-tx` **Version:** `6.2.5`
+**55** **Group:** `org.springframework` **Name:** `spring-tx` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-tx-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-tx-6.2.5.jar/META-INF/license.txt)
     - [spring-tx-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-tx-6.2.5.jar/META-INF/notice.txt)
 
-**57** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `6.2.5`
+**56** **Group:** `org.springframework` **Name:** `spring-web` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-web-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-web-6.2.5.jar/META-INF/license.txt)
     - [spring-web-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-web-6.2.5.jar/META-INF/notice.txt)
 
-**58** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `6.2.5`
+**57** **Group:** `org.springframework` **Name:** `spring-webmvc` **Version:** `6.2.5`
 > - **POM Project URL**: [https://github.com/spring-projects/spring-framework](https://github.com/spring-projects/spring-framework)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-webmvc-6.2.5.jar/META-INF/license.txt](build/reports/dependency-license/spring-webmvc-6.2.5.jar/META-INF/license.txt)
     - [spring-webmvc-6.2.5.jar/META-INF/notice.txt](build/reports/dependency-license/spring-webmvc-6.2.5.jar/META-INF/notice.txt)
 
-**59** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.4.4`
+**58** **Group:** `org.springframework.boot` **Name:** `spring-boot` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-3.4.4.jar/META-INF/NOTICE.txt)
 
-**60** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.4.4`
+**59** **Group:** `org.springframework.boot` **Name:** `spring-boot-autoconfigure` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-autoconfigure-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-autoconfigure-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-autoconfigure-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-autoconfigure-3.4.4.jar/META-INF/NOTICE.txt)
 
-**61** **Group:** `org.springframework.boot` **Name:** `spring-boot-devtools` **Version:** `3.4.4`
+**60** **Group:** `org.springframework.boot` **Name:** `spring-boot-devtools` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-devtools-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-devtools-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-devtools-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-devtools-3.4.4.jar/META-INF/NOTICE.txt)
 
-**62** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.4.4`
+**61** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-3.4.4.jar/META-INF/NOTICE.txt)
 
-**63** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-data-jpa` **Version:** `3.4.4`
+**62** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-data-jpa` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-data-jpa-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-data-jpa-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-data-jpa-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-data-jpa-3.4.4.jar/META-INF/NOTICE.txt)
 
-**64** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-data-redis` **Version:** `3.4.4`
+**63** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-data-redis` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-data-redis-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-data-redis-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-data-redis-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-data-redis-3.4.4.jar/META-INF/NOTICE.txt)
 
-**65** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-jdbc` **Version:** `3.4.4`
+**64** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-jdbc` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-jdbc-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-jdbc-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-jdbc-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-jdbc-3.4.4.jar/META-INF/NOTICE.txt)
 
-**66** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `3.4.4`
+**65** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-json` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-json-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-json-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-json-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-json-3.4.4.jar/META-INF/NOTICE.txt)
 
-**67** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.4.4`
+**66** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-logging` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-logging-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-logging-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-logging-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-logging-3.4.4.jar/META-INF/NOTICE.txt)
 
-**68** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-oauth2-resource-server` **Version:** `3.4.4`
+**67** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-oauth2-resource-server` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-oauth2-resource-server-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-oauth2-resource-server-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-oauth2-resource-server-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-oauth2-resource-server-3.4.4.jar/META-INF/NOTICE.txt)
 
-**69** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-security` **Version:** `3.4.4`
+**68** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-security` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-security-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-security-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-security-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-security-3.4.4.jar/META-INF/NOTICE.txt)
 
-**70** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `3.4.4`
+**69** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-tomcat` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-tomcat-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-tomcat-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-tomcat-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-tomcat-3.4.4.jar/META-INF/NOTICE.txt)
 
-**71** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-validation` **Version:** `3.4.4`
+**70** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-validation` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-validation-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-validation-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-validation-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-validation-3.4.4.jar/META-INF/NOTICE.txt)
 
-**72** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `3.4.4`
+**71** **Group:** `org.springframework.boot` **Name:** `spring-boot-starter-web` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-boot](https://spring.io/projects/spring-boot)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-boot-starter-web-3.4.4.jar/META-INF/LICENSE.txt](build/reports/dependency-license/spring-boot-starter-web-3.4.4.jar/META-INF/LICENSE.txt)
     - [spring-boot-starter-web-3.4.4.jar/META-INF/NOTICE.txt](build/reports/dependency-license/spring-boot-starter-web-3.4.4.jar/META-INF/NOTICE.txt)
 
-**73** **Group:** `org.springframework.data` **Name:** `spring-data-commons` **Version:** `3.4.4`
+**72** **Group:** `org.springframework.data` **Name:** `spring-data-commons` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-data](https://spring.io/projects/spring-data)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-data-commons-3.4.4.jar/license.txt](build/reports/dependency-license/spring-data-commons-3.4.4.jar/license.txt)
     - [spring-data-commons-3.4.4.jar/notice.txt](build/reports/dependency-license/spring-data-commons-3.4.4.jar/notice.txt)
 
-**74** **Group:** `org.springframework.data` **Name:** `spring-data-jpa` **Version:** `3.4.4`
+**73** **Group:** `org.springframework.data` **Name:** `spring-data-jpa` **Version:** `3.4.4`
 > - **POM Project URL**: [https://projects.spring.io/spring-data-jpa](https://projects.spring.io/spring-data-jpa)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-data-jpa-3.4.4.jar/license.txt](build/reports/dependency-license/spring-data-jpa-3.4.4.jar/license.txt)
     - [spring-data-jpa-3.4.4.jar/notice.txt](build/reports/dependency-license/spring-data-jpa-3.4.4.jar/notice.txt)
     - [spring-data-jpa-3.4.4.jar/readme.txt](build/reports/dependency-license/spring-data-jpa-3.4.4.jar/readme.txt)
 
-**75** **Group:** `org.springframework.data` **Name:** `spring-data-keyvalue` **Version:** `3.4.4`
+**74** **Group:** `org.springframework.data` **Name:** `spring-data-keyvalue` **Version:** `3.4.4`
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-data-keyvalue-3.4.4.jar/license.txt](build/reports/dependency-license/spring-data-keyvalue-3.4.4.jar/license.txt)
     - [spring-data-keyvalue-3.4.4.jar/notice.txt](build/reports/dependency-license/spring-data-keyvalue-3.4.4.jar/notice.txt)
 
-**76** **Group:** `org.springframework.data` **Name:** `spring-data-redis` **Version:** `3.4.4`
+**75** **Group:** `org.springframework.data` **Name:** `spring-data-redis` **Version:** `3.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-data-redis](https://spring.io/projects/spring-data-redis)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [spring-data-redis-3.4.4.jar/license.txt](build/reports/dependency-license/spring-data-redis-3.4.4.jar/license.txt)
     - [spring-data-redis-3.4.4.jar/notice.txt](build/reports/dependency-license/spring-data-redis-3.4.4.jar/notice.txt)
 
-**77** **Group:** `org.springframework.security` **Name:** `spring-security-config` **Version:** `6.4.4`
+**76** **Group:** `org.springframework.security` **Name:** `spring-security-config` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**78** **Group:** `org.springframework.security` **Name:** `spring-security-core` **Version:** `6.4.4`
+**77** **Group:** `org.springframework.security` **Name:** `spring-security-core` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**79** **Group:** `org.springframework.security` **Name:** `spring-security-crypto` **Version:** `6.4.4`
+**78** **Group:** `org.springframework.security` **Name:** `spring-security-crypto` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**80** **Group:** `org.springframework.security` **Name:** `spring-security-oauth2-core` **Version:** `6.4.4`
+**79** **Group:** `org.springframework.security` **Name:** `spring-security-oauth2-core` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**81** **Group:** `org.springframework.security` **Name:** `spring-security-oauth2-jose` **Version:** `6.4.4`
+**80** **Group:** `org.springframework.security` **Name:** `spring-security-oauth2-jose` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**82** **Group:** `org.springframework.security` **Name:** `spring-security-oauth2-resource-server` **Version:** `6.4.4`
+**81** **Group:** `org.springframework.security` **Name:** `spring-security-oauth2-resource-server` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**83** **Group:** `org.springframework.security` **Name:** `spring-security-web` **Version:** `6.4.4`
+**82** **Group:** `org.springframework.security` **Name:** `spring-security-web` **Version:** `6.4.4`
 > - **POM Project URL**: [https://spring.io/projects/spring-security](https://spring.io/projects/spring-security)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
-**84** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `2.3`
+**83** **Group:** `org.yaml` **Name:** `snakeyaml` **Version:** `2.3`
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## EPL 1.0
 
-**85** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.3.232`
+**84** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.3.232`
 > - **POM Project URL**: [https://h2database.com](https://h2database.com)
 > - **POM License**: EPL 1.0 - [https://opensource.org/licenses/eclipse-1.0.php](https://opensource.org/licenses/eclipse-1.0.php)
 > - **POM License**: MPL 2.0 - [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/)
 
 ## Eclipse Distribution License - v 1.0
 
-**86** **Group:** `com.sun.istack` **Name:** `istack-commons-runtime` **Version:** `4.1.2`
+**85** **Group:** `com.sun.istack` **Name:** `istack-commons-runtime` **Version:** `4.1.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 > - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
 
-**87** **Group:** `jakarta.activation` **Name:** `jakarta.activation-api` **Version:** `2.1.3`
+**86** **Group:** `jakarta.activation` **Name:** `jakarta.activation-api` **Version:** `2.1.3`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/jakartaee/jaf-api](https://github.com/jakartaee/jaf-api)
@@ -496,7 +490,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.activation-api-2.1.3.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.activation-api-2.1.3.jar/META-INF/LICENSE.md)
     - [jakarta.activation-api-2.1.3.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.activation-api-2.1.3.jar/META-INF/NOTICE.md)
 
-**88** **Group:** `jakarta.persistence` **Name:** `jakarta.persistence-api` **Version:** `3.1.0`
+**87** **Group:** `jakarta.persistence` **Name:** `jakarta.persistence-api` **Version:** `3.1.0`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/eclipse-ee4j/jpa-api](https://github.com/eclipse-ee4j/jpa-api)
@@ -506,7 +500,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.persistence-api-3.1.0.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.persistence-api-3.1.0.jar/META-INF/LICENSE.md)
     - [jakarta.persistence-api-3.1.0.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.persistence-api-3.1.0.jar/META-INF/NOTICE.md)
 
-**89** **Group:** `jakarta.xml.bind` **Name:** `jakarta.xml.bind-api` **Version:** `4.0.2`
+**88** **Group:** `jakarta.xml.bind` **Name:** `jakarta.xml.bind-api` **Version:** `4.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
@@ -515,7 +509,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.xml.bind-api-4.0.2.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.xml.bind-api-4.0.2.jar/META-INF/LICENSE.md)
     - [jakarta.xml.bind-api-4.0.2.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.xml.bind-api-4.0.2.jar/META-INF/NOTICE.md)
 
-**90** **Group:** `org.eclipse.angus` **Name:** `angus-activation` **Version:** `2.0.2`
+**89** **Group:** `org.eclipse.angus` **Name:** `angus-activation` **Version:** `2.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
@@ -524,7 +518,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [angus-activation-2.0.2.jar/META-INF/LICENSE.md](build/reports/dependency-license/angus-activation-2.0.2.jar/META-INF/LICENSE.md)
     - [angus-activation-2.0.2.jar/META-INF/NOTICE.md](build/reports/dependency-license/angus-activation-2.0.2.jar/META-INF/NOTICE.md)
 
-**91** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-core` **Version:** `4.0.5`
+**90** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-core` **Version:** `4.0.5`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
@@ -534,7 +528,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jaxb-core-4.0.5.jar/META-INF/LICENSE.md](build/reports/dependency-license/jaxb-core-4.0.5.jar/META-INF/LICENSE.md)
     - [jaxb-core-4.0.5.jar/META-INF/NOTICE.md](build/reports/dependency-license/jaxb-core-4.0.5.jar/META-INF/NOTICE.md)
 
-**92** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-runtime` **Version:** `4.0.5`
+**91** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-runtime` **Version:** `4.0.5`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
@@ -544,7 +538,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jaxb-runtime-4.0.5.jar/META-INF/LICENSE.md](build/reports/dependency-license/jaxb-runtime-4.0.5.jar/META-INF/LICENSE.md)
     - [jaxb-runtime-4.0.5.jar/META-INF/NOTICE.md](build/reports/dependency-license/jaxb-runtime-4.0.5.jar/META-INF/NOTICE.md)
 
-**93** **Group:** `org.glassfish.jaxb` **Name:** `txw2` **Version:** `4.0.5`
+**92** **Group:** `org.glassfish.jaxb` **Name:** `txw2` **Version:** `4.0.5`
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
@@ -554,13 +548,13 @@ _2025-03-26 11:27:11 EST_
 
 ## Eclipse Public License - v 1.0
 
-**94** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.5.18`
+**93** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.5.18`
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **Manifest License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 (Not Packaged)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 - [https://www.gnu.org/licenses/lgpl-2.1](https://www.gnu.org/licenses/lgpl-2.1)
 
-**95** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.5.18`
+**94** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.5.18`
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **Manifest License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 (Not Packaged)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
@@ -568,14 +562,14 @@ _2025-03-26 11:27:11 EST_
 
 ## Eclipse Public License - v 2.0
 
-**96** **Group:** `com.sun.istack` **Name:** `istack-commons-runtime` **Version:** `4.1.2`
+**95** **Group:** `com.sun.istack` **Name:** `istack-commons-runtime` **Version:** `4.1.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 > - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
 
-**97** **Group:** `jakarta.activation` **Name:** `jakarta.activation-api` **Version:** `2.1.3`
+**96** **Group:** `jakarta.activation` **Name:** `jakarta.activation-api` **Version:** `2.1.3`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/jakartaee/jaf-api](https://github.com/jakartaee/jaf-api)
@@ -585,7 +579,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.activation-api-2.1.3.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.activation-api-2.1.3.jar/META-INF/LICENSE.md)
     - [jakarta.activation-api-2.1.3.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.activation-api-2.1.3.jar/META-INF/NOTICE.md)
 
-**98** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1`
+**97** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Public License - v 2.0 (Not Packaged)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
@@ -594,7 +588,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.annotation-api-2.1.1.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.annotation-api-2.1.1.jar/META-INF/LICENSE.md)
     - [jakarta.annotation-api-2.1.1.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.annotation-api-2.1.1.jar/META-INF/NOTICE.md)
 
-**99** **Group:** `jakarta.inject` **Name:** `jakarta.inject-api` **Version:** `2.0.1`
+**98** **Group:** `jakarta.inject` **Name:** `jakarta.inject-api` **Version:** `2.0.1`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/eclipse-ee4j/injection-api](https://github.com/eclipse-ee4j/injection-api)
@@ -604,7 +598,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.inject-api-2.0.1.jar/META-INF/LICENSE.txt](build/reports/dependency-license/jakarta.inject-api-2.0.1.jar/META-INF/LICENSE.txt)
     - [jakarta.inject-api-2.0.1.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.inject-api-2.0.1.jar/META-INF/NOTICE.md)
 
-**100** **Group:** `jakarta.persistence` **Name:** `jakarta.persistence-api` **Version:** `3.1.0`
+**99** **Group:** `jakarta.persistence` **Name:** `jakarta.persistence-api` **Version:** `3.1.0`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/eclipse-ee4j/jpa-api](https://github.com/eclipse-ee4j/jpa-api)
@@ -614,7 +608,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.persistence-api-3.1.0.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.persistence-api-3.1.0.jar/META-INF/LICENSE.md)
     - [jakarta.persistence-api-3.1.0.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.persistence-api-3.1.0.jar/META-INF/NOTICE.md)
 
-**101** **Group:** `jakarta.transaction` **Name:** `jakarta.transaction-api` **Version:** `2.0.1`
+**100** **Group:** `jakarta.transaction` **Name:** `jakarta.transaction-api` **Version:** `2.0.1`
 > - **Manifest Project URL**: [https://github.com/eclipse-ee4j](https://github.com/eclipse-ee4j)
 > - **Manifest License**: Eclipse Public License - v 2.0 (Not Packaged)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.jta](https://projects.eclipse.org/projects/ee4j.jta)
@@ -623,7 +617,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.transaction-api-2.0.1.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.transaction-api-2.0.1.jar/META-INF/LICENSE.md)
     - [jakarta.transaction-api-2.0.1.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.transaction-api-2.0.1.jar/META-INF/NOTICE.md)
 
-**102** **Group:** `jakarta.validation` **Name:** `jakarta.validation-api` **Version:** `3.0.2`
+**101** **Group:** `jakarta.validation` **Name:** `jakarta.validation-api` **Version:** `3.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://beanvalidation.org](https://beanvalidation.org)
@@ -631,7 +625,7 @@ _2025-03-26 11:27:11 EST_
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 > - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
 
-**103** **Group:** `jakarta.xml.bind` **Name:** `jakarta.xml.bind-api` **Version:** `4.0.2`
+**102** **Group:** `jakarta.xml.bind` **Name:** `jakarta.xml.bind-api` **Version:** `4.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
@@ -640,11 +634,11 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.xml.bind-api-4.0.2.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.xml.bind-api-4.0.2.jar/META-INF/LICENSE.md)
     - [jakarta.xml.bind-api-4.0.2.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.xml.bind-api-4.0.2.jar/META-INF/NOTICE.md)
 
-**104** **Group:** `org.aspectj` **Name:** `aspectjweaver` **Version:** `1.9.23`
+**103** **Group:** `org.aspectj` **Name:** `aspectjweaver` **Version:** `1.9.23`
 > - **POM Project URL**: [https://www.eclipse.org/aspectj/](https://www.eclipse.org/aspectj/)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 
-**105** **Group:** `org.eclipse.angus` **Name:** `angus-activation` **Version:** `2.0.2`
+**104** **Group:** `org.eclipse.angus` **Name:** `angus-activation` **Version:** `2.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
@@ -653,7 +647,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [angus-activation-2.0.2.jar/META-INF/LICENSE.md](build/reports/dependency-license/angus-activation-2.0.2.jar/META-INF/LICENSE.md)
     - [angus-activation-2.0.2.jar/META-INF/NOTICE.md](build/reports/dependency-license/angus-activation-2.0.2.jar/META-INF/NOTICE.md)
 
-**106** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-core` **Version:** `4.0.5`
+**105** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-core` **Version:** `4.0.5`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
@@ -663,7 +657,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jaxb-core-4.0.5.jar/META-INF/LICENSE.md](build/reports/dependency-license/jaxb-core-4.0.5.jar/META-INF/LICENSE.md)
     - [jaxb-core-4.0.5.jar/META-INF/NOTICE.md](build/reports/dependency-license/jaxb-core-4.0.5.jar/META-INF/NOTICE.md)
 
-**107** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-runtime` **Version:** `4.0.5`
+**106** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-runtime` **Version:** `4.0.5`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
@@ -673,7 +667,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jaxb-runtime-4.0.5.jar/META-INF/LICENSE.md](build/reports/dependency-license/jaxb-runtime-4.0.5.jar/META-INF/LICENSE.md)
     - [jaxb-runtime-4.0.5.jar/META-INF/NOTICE.md](build/reports/dependency-license/jaxb-runtime-4.0.5.jar/META-INF/NOTICE.md)
 
-**108** **Group:** `org.glassfish.jaxb` **Name:** `txw2` **Version:** `4.0.5`
+**107** **Group:** `org.glassfish.jaxb` **Name:** `txw2` **Version:** `4.0.5`
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
@@ -683,82 +677,82 @@ _2025-03-26 11:27:11 EST_
 
 ## GNU Affero General Public License v3
 
-**109** **Group:** `com.itextpdf` **Name:** `barcodes` **Version:** `9.1.0`
+**108** **Group:** `com.itextpdf` **Name:** `barcodes` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**110** **Group:** `com.itextpdf` **Name:** `bouncy-castle-connector` **Version:** `9.1.0`
+**109** **Group:** `com.itextpdf` **Name:** `bouncy-castle-connector` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**111** **Group:** `com.itextpdf` **Name:** `commons` **Version:** `9.1.0`
+**110** **Group:** `com.itextpdf` **Name:** `commons` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**112** **Group:** `com.itextpdf` **Name:** `font-asian` **Version:** `9.1.0`
+**111** **Group:** `com.itextpdf` **Name:** `font-asian` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 > - **POM License**: Various licenses (see individual files)
 
-**113** **Group:** `com.itextpdf` **Name:** `forms` **Version:** `9.1.0`
+**112** **Group:** `com.itextpdf` **Name:** `forms` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**114** **Group:** `com.itextpdf` **Name:** `html2pdf` **Version:** `6.1.0`
+**113** **Group:** `com.itextpdf` **Name:** `html2pdf` **Version:** `6.1.0`
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**115** **Group:** `com.itextpdf` **Name:** `hyph` **Version:** `9.1.0`
+**114** **Group:** `com.itextpdf` **Name:** `hyph` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 > - **POM License**: Various licenses (see individual files)
 > - **Embedded license files**: [hyph-9.1.0.jar/com/itextpdf/hyph/readme.txt](build/reports/dependency-license/hyph-9.1.0.jar/com/itextpdf/hyph/readme.txt)
 
-**116** **Group:** `com.itextpdf` **Name:** `io` **Version:** `9.1.0`
+**115** **Group:** `com.itextpdf` **Name:** `io` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**117** **Group:** `com.itextpdf` **Name:** `itext-core` **Version:** `9.1.0`
+**116** **Group:** `com.itextpdf` **Name:** `itext-core` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**118** **Group:** `com.itextpdf` **Name:** `kernel` **Version:** `9.1.0`
+**117** **Group:** `com.itextpdf` **Name:** `kernel` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**119** **Group:** `com.itextpdf` **Name:** `layout` **Version:** `9.1.0`
+**118** **Group:** `com.itextpdf` **Name:** `layout` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**120** **Group:** `com.itextpdf` **Name:** `pdfa` **Version:** `9.1.0`
+**119** **Group:** `com.itextpdf` **Name:** `pdfa` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**121** **Group:** `com.itextpdf` **Name:** `pdfua` **Version:** `9.1.0`
+**120** **Group:** `com.itextpdf` **Name:** `pdfua` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**122** **Group:** `com.itextpdf` **Name:** `sign` **Version:** `9.1.0`
+**121** **Group:** `com.itextpdf` **Name:** `sign` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**123** **Group:** `com.itextpdf` **Name:** `styled-xml-parser` **Version:** `9.1.0`
+**122** **Group:** `com.itextpdf` **Name:** `styled-xml-parser` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
-**124** **Group:** `com.itextpdf` **Name:** `svg` **Version:** `9.1.0`
+**123** **Group:** `com.itextpdf` **Name:** `svg` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 
 ## GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception
 
-**125** **Group:** `com.sun.istack` **Name:** `istack-commons-runtime` **Version:** `4.1.2`
+**124** **Group:** `com.sun.istack` **Name:** `istack-commons-runtime` **Version:** `4.1.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 > - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
 
-**126** **Group:** `jakarta.activation` **Name:** `jakarta.activation-api` **Version:** `2.1.3`
+**125** **Group:** `jakarta.activation` **Name:** `jakarta.activation-api` **Version:** `2.1.3`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/jakartaee/jaf-api](https://github.com/jakartaee/jaf-api)
@@ -768,7 +762,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.activation-api-2.1.3.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.activation-api-2.1.3.jar/META-INF/LICENSE.md)
     - [jakarta.activation-api-2.1.3.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.activation-api-2.1.3.jar/META-INF/NOTICE.md)
 
-**127** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1`
+**126** **Group:** `jakarta.annotation` **Name:** `jakarta.annotation-api` **Version:** `2.1.1`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Public License - v 2.0 (Not Packaged)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.ca](https://projects.eclipse.org/projects/ee4j.ca)
@@ -777,7 +771,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.annotation-api-2.1.1.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.annotation-api-2.1.1.jar/META-INF/LICENSE.md)
     - [jakarta.annotation-api-2.1.1.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.annotation-api-2.1.1.jar/META-INF/NOTICE.md)
 
-**128** **Group:** `jakarta.inject` **Name:** `jakarta.inject-api` **Version:** `2.0.1`
+**127** **Group:** `jakarta.inject` **Name:** `jakarta.inject-api` **Version:** `2.0.1`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/eclipse-ee4j/injection-api](https://github.com/eclipse-ee4j/injection-api)
@@ -787,7 +781,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.inject-api-2.0.1.jar/META-INF/LICENSE.txt](build/reports/dependency-license/jakarta.inject-api-2.0.1.jar/META-INF/LICENSE.txt)
     - [jakarta.inject-api-2.0.1.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.inject-api-2.0.1.jar/META-INF/NOTICE.md)
 
-**129** **Group:** `jakarta.persistence` **Name:** `jakarta.persistence-api` **Version:** `3.1.0`
+**128** **Group:** `jakarta.persistence` **Name:** `jakarta.persistence-api` **Version:** `3.1.0`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://github.com/eclipse-ee4j/jpa-api](https://github.com/eclipse-ee4j/jpa-api)
@@ -797,7 +791,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.persistence-api-3.1.0.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.persistence-api-3.1.0.jar/META-INF/LICENSE.md)
     - [jakarta.persistence-api-3.1.0.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.persistence-api-3.1.0.jar/META-INF/NOTICE.md)
 
-**130** **Group:** `jakarta.transaction` **Name:** `jakarta.transaction-api` **Version:** `2.0.1`
+**129** **Group:** `jakarta.transaction` **Name:** `jakarta.transaction-api` **Version:** `2.0.1`
 > - **Manifest Project URL**: [https://github.com/eclipse-ee4j](https://github.com/eclipse-ee4j)
 > - **Manifest License**: Eclipse Public License - v 2.0 (Not Packaged)
 > - **POM Project URL**: [https://projects.eclipse.org/projects/ee4j.jta](https://projects.eclipse.org/projects/ee4j.jta)
@@ -806,7 +800,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.transaction-api-2.0.1.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.transaction-api-2.0.1.jar/META-INF/LICENSE.md)
     - [jakarta.transaction-api-2.0.1.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.transaction-api-2.0.1.jar/META-INF/NOTICE.md)
 
-**131** **Group:** `jakarta.validation` **Name:** `jakarta.validation-api` **Version:** `3.0.2`
+**130** **Group:** `jakarta.validation` **Name:** `jakarta.validation-api` **Version:** `3.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Apache License, Version 2.0 (Not Packaged)
 > - **POM Project URL**: [https://beanvalidation.org](https://beanvalidation.org)
@@ -814,7 +808,7 @@ _2025-03-26 11:27:11 EST_
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 > - **POM License**: GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception - [https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html)
 
-**132** **Group:** `jakarta.xml.bind` **Name:** `jakarta.xml.bind-api` **Version:** `4.0.2`
+**131** **Group:** `jakarta.xml.bind` **Name:** `jakarta.xml.bind-api` **Version:** `4.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
@@ -823,7 +817,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jakarta.xml.bind-api-4.0.2.jar/META-INF/LICENSE.md](build/reports/dependency-license/jakarta.xml.bind-api-4.0.2.jar/META-INF/LICENSE.md)
     - [jakarta.xml.bind-api-4.0.2.jar/META-INF/NOTICE.md](build/reports/dependency-license/jakarta.xml.bind-api-4.0.2.jar/META-INF/NOTICE.md)
 
-**133** **Group:** `org.eclipse.angus` **Name:** `angus-activation` **Version:** `2.0.2`
+**132** **Group:** `org.eclipse.angus` **Name:** `angus-activation` **Version:** `2.0.2`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
@@ -832,7 +826,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [angus-activation-2.0.2.jar/META-INF/LICENSE.md](build/reports/dependency-license/angus-activation-2.0.2.jar/META-INF/LICENSE.md)
     - [angus-activation-2.0.2.jar/META-INF/NOTICE.md](build/reports/dependency-license/angus-activation-2.0.2.jar/META-INF/NOTICE.md)
 
-**134** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-core` **Version:** `4.0.5`
+**133** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-core` **Version:** `4.0.5`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
@@ -842,7 +836,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jaxb-core-4.0.5.jar/META-INF/LICENSE.md](build/reports/dependency-license/jaxb-core-4.0.5.jar/META-INF/LICENSE.md)
     - [jaxb-core-4.0.5.jar/META-INF/NOTICE.md](build/reports/dependency-license/jaxb-core-4.0.5.jar/META-INF/NOTICE.md)
 
-**135** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-runtime` **Version:** `4.0.5`
+**134** **Group:** `org.glassfish.jaxb` **Name:** `jaxb-runtime` **Version:** `4.0.5`
 > - **Manifest Project URL**: [https://www.eclipse.org](https://www.eclipse.org)
 > - **Manifest License**: Eclipse Distribution License - v 1.0 (Not Packaged)
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
@@ -852,7 +846,7 @@ _2025-03-26 11:27:11 EST_
 > - **Embedded license files**: [jaxb-runtime-4.0.5.jar/META-INF/LICENSE.md](build/reports/dependency-license/jaxb-runtime-4.0.5.jar/META-INF/LICENSE.md)
     - [jaxb-runtime-4.0.5.jar/META-INF/NOTICE.md](build/reports/dependency-license/jaxb-runtime-4.0.5.jar/META-INF/NOTICE.md)
 
-**136** **Group:** `org.glassfish.jaxb` **Name:** `txw2` **Version:** `4.0.5`
+**135** **Group:** `org.glassfish.jaxb` **Name:** `txw2` **Version:** `4.0.5`
 > - **POM Project URL**: [https://eclipse-ee4j.github.io/jaxb-ri/](https://eclipse-ee4j.github.io/jaxb-ri/)
 > - **POM License**: Eclipse Distribution License - v 1.0 - [https://www.eclipse.org/org/documents/edl-v10.html](https://www.eclipse.org/org/documents/edl-v10.html)
 > - **POM License**: Eclipse Public License - v 2.0 - [https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt](https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
@@ -862,72 +856,72 @@ _2025-03-26 11:27:11 EST_
 
 ## GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1
 
-**137** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.5.18`
+**136** **Group:** `ch.qos.logback` **Name:** `logback-classic` **Version:** `1.5.18`
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **Manifest License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 (Not Packaged)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 - [https://www.gnu.org/licenses/lgpl-2.1](https://www.gnu.org/licenses/lgpl-2.1)
 
-**138** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.5.18`
+**137** **Group:** `ch.qos.logback` **Name:** `logback-core` **Version:** `1.5.18`
 > - **Manifest Project URL**: [http://www.qos.ch](http://www.qos.ch)
 > - **Manifest License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 (Not Packaged)
 > - **POM License**: Eclipse Public License - v 1.0 - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 > - **POM License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 - [https://www.gnu.org/licenses/lgpl-2.1](https://www.gnu.org/licenses/lgpl-2.1)
 
-**139** **Group:** `org.hibernate.orm` **Name:** `hibernate-core` **Version:** `6.6.11.Final`
+**138** **Group:** `org.hibernate.orm` **Name:** `hibernate-core` **Version:** `6.6.11.Final`
 > - **Manifest Project URL**: [https://www.hibernate.org/orm/6.6](https://www.hibernate.org/orm/6.6)
 > - **POM Project URL**: [https://hibernate.org/orm](https://hibernate.org/orm)
 > - **POM License**: GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1 - [https://www.gnu.org/licenses/lgpl-2.1](https://www.gnu.org/licenses/lgpl-2.1)
 
 ## MIT License
 
-**140** **Group:** `com.microsoft.sqlserver` **Name:** `mssql-jdbc` **Version:** `12.8.1.jre11`
+**139** **Group:** `com.microsoft.sqlserver` **Name:** `mssql-jdbc` **Version:** `12.8.1.jre11`
 > - **POM Project URL**: [https://github.com/Microsoft/mssql-jdbc](https://github.com/Microsoft/mssql-jdbc)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 
-**141** **Group:** `io.lettuce` **Name:** `lettuce-core` **Version:** `6.4.2.RELEASE`
+**140** **Group:** `io.lettuce` **Name:** `lettuce-core` **Version:** `6.4.2.RELEASE`
 > - **POM Project URL**: [http://github.com/lettuce-io/lettuce-core](http://github.com/lettuce-io/lettuce-core)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 > - **Embedded license files**: [lettuce-core-6.4.2.RELEASE.jar/META-INF/LICENSE](build/reports/dependency-license/lettuce-core-6.4.2.RELEASE.jar/META-INF/LICENSE)
     - [lettuce-core-6.4.2.RELEASE.jar/META-INF/NOTICE](build/reports/dependency-license/lettuce-core-6.4.2.RELEASE.jar/META-INF/NOTICE)
 
-**142** **Group:** `me.paulschwarz` **Name:** `spring-dotenv` **Version:** `4.0.0`
+**141** **Group:** `me.paulschwarz` **Name:** `spring-dotenv` **Version:** `4.0.0`
 > - **POM Project URL**: [https://github.com/paulschwarz/spring-dotenv](https://github.com/paulschwarz/spring-dotenv)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 
-**143** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.48.3`
+**142** **Group:** `org.checkerframework` **Name:** `checker-qual` **Version:** `3.48.3`
 > - **Manifest License**: MIT License (Not Packaged)
 > - **POM Project URL**: [https://checkerframework.org/](https://checkerframework.org/)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 > - **Embedded license files**: [checker-qual-3.48.3.jar/META-INF/LICENSE.txt](build/reports/dependency-license/checker-qual-3.48.3.jar/META-INF/LICENSE.txt)
 
-**144** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.17`
+**143** **Group:** `org.slf4j` **Name:** `jul-to-slf4j` **Version:** `2.0.17`
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 > - **Embedded license files**: [jul-to-slf4j-2.0.17.jar/META-INF/LICENSE.txt](build/reports/dependency-license/jul-to-slf4j-2.0.17.jar/META-INF/LICENSE.txt)
 
-**145** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.17`
+**144** **Group:** `org.slf4j` **Name:** `slf4j-api` **Version:** `2.0.17`
 > - **Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 > - **Embedded license files**: [slf4j-api-2.0.17.jar/META-INF/LICENSE.txt](build/reports/dependency-license/slf4j-api-2.0.17.jar/META-INF/LICENSE.txt)
 
 ## MIT-0
 
-**146** **Group:** `org.reactivestreams` **Name:** `reactive-streams` **Version:** `1.0.4`
+**145** **Group:** `org.reactivestreams` **Name:** `reactive-streams` **Version:** `1.0.4`
 > - **Manifest Project URL**: [http://reactive-streams.org](http://reactive-streams.org)
 > - **POM Project URL**: [http://www.reactive-streams.org/](http://www.reactive-streams.org/)
 > - **POM License**: MIT-0 - [https://spdx.org/licenses/MIT-0.html](https://spdx.org/licenses/MIT-0.html)
 
 ## MPL 2.0
 
-**147** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.3.232`
+**146** **Group:** `com.h2database` **Name:** `h2` **Version:** `2.3.232`
 > - **POM Project URL**: [https://h2database.com](https://h2database.com)
 > - **POM License**: EPL 1.0 - [https://opensource.org/licenses/eclipse-1.0.php](https://opensource.org/licenses/eclipse-1.0.php)
 > - **POM License**: MPL 2.0 - [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/)
 
 ## The 2-Clause BSD License
 
-**148** **Group:** `org.postgresql` **Name:** `postgresql` **Version:** `42.7.5`
+**147** **Group:** `org.postgresql` **Name:** `postgresql` **Version:** `42.7.5`
 > - **Manifest Project URL**: [https://jdbc.postgresql.org/](https://jdbc.postgresql.org/)
 > - **Manifest License**: The 2-Clause BSD License (Not Packaged)
 > - **POM Project URL**: [https://jdbc.postgresql.org](https://jdbc.postgresql.org)
@@ -940,18 +934,18 @@ _2025-03-26 11:27:11 EST_
 
 ## The 3-Clause BSD License
 
-**149** **Group:** `org.antlr` **Name:** `antlr4-runtime` **Version:** `4.13.0`
+**148** **Group:** `org.antlr` **Name:** `antlr4-runtime` **Version:** `4.13.0`
 > - **Manifest Project URL**: [https://www.antlr.org/](https://www.antlr.org/)
 > - **POM License**: The 3-Clause BSD License - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 ## Various licenses (see individual files)
 
-**150** **Group:** `com.itextpdf` **Name:** `font-asian` **Version:** `9.1.0`
+**149** **Group:** `com.itextpdf` **Name:** `font-asian` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 > - **POM License**: Various licenses (see individual files)
 
-**151** **Group:** `com.itextpdf` **Name:** `hyph` **Version:** `9.1.0`
+**150** **Group:** `com.itextpdf` **Name:** `hyph` **Version:** `9.1.0`
 > - **POM Project URL**: [https://itextpdf.com/](https://itextpdf.com/)
 > - **POM License**: GNU Affero General Public License v3 - [http://www.fsf.org/licensing/licenses/agpl-3.0.html](http://www.fsf.org/licensing/licenses/agpl-3.0.html)
 > - **POM License**: Various licenses (see individual files)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.spotless)
     alias(libs.plugins.license.report)
+    alias(libs.plugins.kover)
 }
 
 group = "io.github.kingg22"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,3 +87,9 @@ licenseReport {
     renderers = arrayOf(InventoryMarkdownReportRenderer("THIRD-PARTY.md"))
     filters = arrayOf(LicenseBundleNormalizer())
 }
+
+kover {
+    reports.filters.excludes {
+        annotatedBy("io.mcarle.konvert.api.GeneratedKonverter")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ dotenv-java = "3.2.0"
 konvert = "4.0.1"
 spotless = "7.0.2"
 gradle-license-report = "2.9"
+kover = "0.9.1"
 
 [libraries]
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
@@ -92,3 +93,4 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 ksp =  { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 license-report = { id = "com.github.jk1.dependency-license-report", version.ref = "gradle-license-report" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
## Resumen por Sourcery

Añade el plugin Kover para la cobertura de código Java y Kotlin

Build:
- Se añadió el plugin Kover a la configuración de build del proyecto
- Se configuró Kover para excluir las clases Konverter generadas de los informes de cobertura

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Kover plugin for code coverage of Java and Kotlin code

Build:
- Added Kover plugin to the project's build configuration
- Configured Kover to exclude generated Konverter classes from coverage reports

</details>