### PR TITLE
perf: remove use of java.util.optional to use nullable types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "io.github.kingg22"
-version = "0.14.0"
+version = "0.14.1"
 
 java {
     toolchain {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
         ipv4_address: 172.22.0.3
 
   api-vacunas:
-    image: api-vacunas-panama:0.14.0
+    image: api-vacunas-panama:0.14.1
     container_name: api-spring-vacunas
     env_file:
       - "containers/secrets/docker.env"

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/repository/DireccionRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/repository/DireccionRepository.kt
@@ -4,13 +4,12 @@ package io.github.kingg22.api.vacunas.panama.modules.direccion.repository
 
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.Optional
 import java.util.UUID
 
 interface DireccionRepository : JpaRepository<Direccion, UUID> {
-    fun findDireccionByDireccionAndDistrito_Id(direccion: String?, idDistrito: Int): Optional<List<Direccion>>
+    fun findDireccionByDireccionAndDistrito_Id(direccion: String?, idDistrito: Int): List<Direccion>?
 
-    fun findDireccionByDireccionStartingWith(direccion: String?): Optional<List<Direccion>>
+    fun findDireccionByDireccionStartingWith(direccion: String?): List<Direccion>?
 
-    fun findDireccionByDireccionAndDistrito_Nombre(direccion: String, distrito: String?): Optional<List<Direccion>>
+    fun findDireccionByDireccionAndDistrito_Nombre(direccion: String, distrito: String?): List<Direccion>?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionService.kt
@@ -4,10 +4,9 @@ import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DistritoDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.ProvinciaDto
 import jakarta.validation.Valid
-import java.util.Optional
 
 /**
- * Service interface for managing address-related operations such as creating, retrieving and searching for provinces,
+ * Service interface for managing address-related operations such as creating, retrieving, and searching for provinces,
  * districts, and specific addresses.
  */
 interface DireccionService {
@@ -54,7 +53,7 @@ interface DireccionService {
      * Searches for an address entity matching the fields of the provided [DireccionDto].
      *
      * @param direccionDto DTO containing the address fields to search for.
-     * @return [Optional] of [DireccionDto], present if a match is found, empty otherwise.
+     * @return [DireccionDto], present if a match is found, null otherwise.
      */
-    fun getDireccionByDto(direccionDto: DireccionDto): Optional<DireccionDto>
+    fun getDireccionByDto(direccionDto: DireccionDto): DireccionDto?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorService.kt
@@ -1,7 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.service
 
 import io.github.kingg22.api.vacunas.panama.modules.doctor.dto.DoctorDto
-import java.util.Optional
 import java.util.UUID
 
 /** Service interface for managing and retrieving doctor-related information. */
@@ -11,7 +10,7 @@ fun interface DoctorService {
      * Retrieves a [DoctorDto] by its unique doctor ID.
      *
      * @param idDoctor UUID of the doctor to retrieve.
-     * @return [Optional] containing the doctor if found, or empty if not.
+     * @return The doctor if found, or null if not.
      */
-    fun getDoctorById(idDoctor: UUID): Optional<DoctorDto>
+    fun getDoctorById(idDoctor: UUID): DoctorDto?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorServiceImpl.kt
@@ -1,14 +1,12 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.service
 
-import io.github.kingg22.api.vacunas.panama.modules.doctor.dto.DoctorDto
 import io.github.kingg22.api.vacunas.panama.modules.doctor.entity.toDoctorDto
 import io.github.kingg22.api.vacunas.panama.modules.doctor.repository.DoctorRepository
 import org.springframework.stereotype.Service
-import java.util.Optional
 import java.util.UUID
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class DoctorServiceImpl(private val doctorRepository: DoctorRepository) : DoctorService {
-    override fun getDoctorById(idDoctor: UUID): Optional<DoctorDto> =
-        doctorRepository.findById(idDoctor).map { it.toDoctorDto() }
+    override fun getDoctorById(idDoctor: UUID) = doctorRepository.findById(idDoctor).getOrNull()?.toDoctorDto()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/repository/FabricanteRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/repository/FabricanteRepository.kt
@@ -4,11 +4,10 @@ package io.github.kingg22.api.vacunas.panama.modules.fabricante.repository
 
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.Optional
 import java.util.UUID
 
 interface FabricanteRepository : JpaRepository<Fabricante, UUID> {
-    fun findByLicencia(licencia: String): Optional<Fabricante>
+    fun findByLicencia(licencia: String): Fabricante?
 
-    fun findByUsuario_Id(idUsuario: UUID): Optional<Fabricante>
+    fun findByUsuario_Id(idUsuario: UUID): Fabricante?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/service/FabricanteService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/service/FabricanteService.kt
@@ -1,7 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.fabricante.service
 
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.dto.FabricanteDto
-import java.util.Optional
 import java.util.UUID
 
 /** Service interface for managing and retrieving fabricante-related information. */
@@ -10,15 +9,15 @@ interface FabricanteService {
      * Retrieves a [FabricanteDto] associated with the specific licencia.
      *
      * @param licencia String with the licencia linked to the fabricante.
-     * @return [Optional] containing the fabricante if found or empty if not.
+     * @return The fabricante if found or null if not.
      */
-    fun getFabricante(licencia: String): Optional<FabricanteDto>
+    fun getFabricante(licencia: String): FabricanteDto?
 
     /**
      * Retrieves a [FabricanteDto] associated with the specified user ID.
      *
      * @param idUser UUID of the user linked to the doctor.
-     * @return [Optional] containing the fabricante if found or empty if not.
+     * @return The fabricante if found or null if not.
      */
-    fun getFabricanteByUserID(idUser: UUID): Optional<FabricanteDto>
+    fun getFabricanteByUserID(idUser: UUID): FabricanteDto?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/service/FabricanteServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/service/FabricanteServiceImpl.kt
@@ -1,17 +1,13 @@
 package io.github.kingg22.api.vacunas.panama.modules.fabricante.service
 
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.dto.FabricanteDto
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.toFabricanteDto
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.repository.FabricanteRepository
 import org.springframework.stereotype.Service
-import java.util.Optional
 import java.util.UUID
 
 @Service
 class FabricanteServiceImpl(private val fabricanteRepository: FabricanteRepository) : FabricanteService {
-    override fun getFabricante(licencia: String): Optional<FabricanteDto> =
-        fabricanteRepository.findByLicencia(licencia).map { it.toFabricanteDto() }
+    override fun getFabricante(licencia: String) = fabricanteRepository.findByLicencia(licencia)?.toFabricanteDto()
 
-    override fun getFabricanteByUserID(idUser: UUID): Optional<FabricanteDto> =
-        fabricanteRepository.findByUsuario_Id(idUser).map { it.toFabricanteDto() }
+    override fun getFabricanteByUserID(idUser: UUID) = fabricanteRepository.findByUsuario_Id(idUser)?.toFabricanteDto()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/repository/PacienteRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/repository/PacienteRepository.kt
@@ -5,7 +5,6 @@ import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.Optional
 import java.util.UUID
 
 interface PacienteRepository : JpaRepository<Paciente, UUID> {
@@ -15,13 +14,13 @@ interface PacienteRepository : JpaRepository<Paciente, UUID> {
         @Param("vacuna") vacuna: UUID? = null,
     ): List<ViewPacienteVacunaEnfermedadDto>
 
-    fun findByIdentificacionTemporal(idTemporal: String?): Optional<Paciente>
+    fun findByIdentificacionTemporal(idTemporal: String?): Paciente?
 
-    fun findByCedula(cedula: String?): Optional<Paciente>
+    fun findByCedula(cedula: String?): Paciente?
 
-    fun findByPasaporte(pasaporte: String?): Optional<Paciente>
+    fun findByPasaporte(pasaporte: String?): Paciente?
 
-    fun findByCorreo(correo: String?): Optional<Paciente>
+    fun findByCorreo(correo: String?): Paciente?
 
-    fun findByTelefono(telefono: String?): Optional<Paciente>
+    fun findByTelefono(telefono: String?): Paciente?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/service/PacienteService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/service/PacienteService.kt
@@ -3,7 +3,6 @@ package io.github.kingg22.api.vacunas.panama.modules.paciente.service
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.PacienteDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.ViewPacienteVacunaEnfermedadDto
 import io.github.kingg22.api.vacunas.panama.response.ApiContentResponse
-import java.util.Optional
 import java.util.UUID
 
 /**
@@ -31,9 +30,9 @@ interface PacienteService {
      * Retrieves a [PacienteDto] by its unique ID.
      *
      * @param idPaciente UUID of the patient.
-     * @return [Optional] of [PacienteDto] if found, or empty if not.
+     * @return [PacienteDto] if found, or null if not.
      */
-    fun getPacienteById(idPaciente: UUID): Optional<PacienteDto>
+    fun getPacienteById(idPaciente: UUID): PacienteDto?
 
     /**
      * Retrieves a list of vaccines and diseases linked to the given patient.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/repository/PersonaRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/repository/PersonaRepository.kt
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotNull
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.Optional
 import java.util.UUID
 
 interface PersonaRepository : JpaRepository<Persona, UUID> {
@@ -22,9 +21,9 @@ interface PersonaRepository : JpaRepository<Persona, UUID> {
         @Param("cedula") cedula: String?,
         @Param("pasaporte") pasaporte: String?,
         @Param("correo") correo: String?,
-    ): Optional<Persona>
+    ): Persona?
 
-    fun findByUsuario_Id(id: @NotNull UUID): Optional<Persona>
+    fun findByUsuario_Id(id: @NotNull UUID): Persona?
 
-    fun findByUsuario_Username(username: @NotNull String): Optional<Persona>
+    fun findByUsuario_Username(username: @NotNull String): Persona?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaService.kt
@@ -2,7 +2,6 @@ package io.github.kingg22.api.vacunas.panama.modules.persona.service
 
 import io.github.kingg22.api.vacunas.panama.modules.persona.dto.PersonaDto
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
-import java.util.Optional
 import java.util.UUID
 
 /** Service interface for managing and retrieving persona-related information. */
@@ -12,14 +11,14 @@ interface PersonaService {
      * (maybe can be [PersonaDto.cedula], [PersonaDto.pasaporte], [PersonaDto.correo] or `PersonaDto.usuario.username`).
      *
      * @param identifier UUID of the persona to retrieve.
-     * @return [Optional] containing the persona if found, or empty if not.
+     * @return The persona if found, or null if not.
      * @see io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto.username
      */
     @Deprecated(
         message = "This function be change to use DTO when jooq is set as ORM",
         replaceWith = ReplaceWith("getPersonaDto(identifier)"),
     )
-    fun getPersona(identifier: String): Optional<Persona>
+    fun getPersona(identifier: String): Persona?
 
     /**
      * Retrieves a [PersonaDto] entity by an identifier
@@ -35,7 +34,7 @@ interface PersonaService {
      * Retrieves a [PersonaDto] associated with the specified user ID.
      *
      * @param idUser UUID of the user linked to the persona.
-     * @return [Optional] containing the persona if found, or empty if not.
+     * @return The persona if found, or null if not.
      */
-    fun getPersonaByUserID(idUser: UUID): Optional<PersonaDto>
+    fun getPersonaByUserID(idUser: UUID): PersonaDto?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
@@ -7,9 +7,7 @@ import io.github.kingg22.api.vacunas.panama.modules.persona.repository.PersonaRe
 import io.github.kingg22.api.vacunas.panama.util.FormatterUtil.formatToSearch
 import jakarta.validation.constraints.NotNull
 import org.springframework.stereotype.Service
-import java.util.Optional
 import java.util.UUID
-import kotlin.jvm.optionals.getOrNull
 
 @Service
 class PersonaServiceImpl(private val personaRepository: PersonaRepository) : PersonaService {
@@ -17,22 +15,18 @@ class PersonaServiceImpl(private val personaRepository: PersonaRepository) : Per
         "This function be change to use DTO when jooq is set as ORM",
         replaceWith = ReplaceWith("getPersonaDto(identifier)"),
     )
-    override fun getPersona(identifier: @NotNull String): Optional<Persona> {
+    override fun getPersona(identifier: @NotNull String): Persona? {
         val result = formatToSearch(identifier)
         val personaOpt = this.personaRepository.findByCedulaOrPasaporteOrCorreo(
             result.cedula,
             result.pasaporte,
             result.correo,
         )
-        return if (personaOpt.isPresent) {
-            personaOpt
-        } else {
-            personaRepository.findByUsuario_Username(identifier)
-        }
+        return personaOpt ?: personaRepository.findByUsuario_Username(identifier)
     }
 
-    override fun getPersonaDto(identifier: String): PersonaDto? = getPersona(identifier).getOrNull()?.toPersonaDto()
+    override fun getPersonaDto(identifier: String): PersonaDto? = getPersona(identifier)?.toPersonaDto()
 
-    override fun getPersonaByUserID(idUser: @NotNull UUID): Optional<PersonaDto> =
-        personaRepository.findByUsuario_Id(idUser).map { it.toPersonaDto() }
+    override fun getPersonaByUserID(idUser: @NotNull UUID): PersonaDto? =
+        personaRepository.findByUsuario_Id(idUser)?.toPersonaDto()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeService.kt
@@ -2,11 +2,25 @@ package io.github.kingg22.api.vacunas.panama.modules.sede.service
 
 import io.github.kingg22.api.vacunas.panama.modules.common.dto.UUIDNombreDto
 import io.github.kingg22.api.vacunas.panama.modules.sede.dto.SedeDto
-import java.util.Optional
 import java.util.UUID
 
+/**
+ * Service interface for managing entities related to `Sede`.
+ * Provides methods to retrieve data about `Sedes` and perform related operations.
+ */
 interface SedeService {
+    /**
+     * Retrieves a list of `Sede` with their IDs and corresponding names.
+     *
+     * @return a list of [UUIDNombreDto] containing the UUID and name of each `Sede`.
+     */
     fun getIdNombreSedes(): List<UUIDNombreDto>
 
-    fun getSedeById(id: UUID): Optional<SedeDto>
+    /**
+     * Retrieves the details of a `Sede` entity based on its unique identifier.
+     *
+     * @param id the unique identifier of the `Sede` to retrieve
+     * @return a [SedeDto] containing the details of the `Sede`, or null if no found.
+     */
+    fun getSedeById(id: UUID): SedeDto?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeServiceImpl.kt
@@ -1,17 +1,16 @@
 package io.github.kingg22.api.vacunas.panama.modules.sede.service
 
 import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
-import io.github.kingg22.api.vacunas.panama.modules.sede.dto.SedeDto
 import io.github.kingg22.api.vacunas.panama.modules.sede.entity.toSedeDto
 import io.github.kingg22.api.vacunas.panama.modules.sede.repository.SedeRepository
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
-import java.util.Optional
 import java.util.UUID
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class SedeServiceImpl(private val sedeRepository: SedeRepository) : SedeService {
-    override fun getSedeById(id: UUID): Optional<SedeDto> = sedeRepository.findById(id).map { it.toSedeDto() }
+    override fun getSedeById(id: UUID) = sedeRepository.findById(id).getOrNull()?.toSedeDto()
 
     @Cacheable(
         cacheNames = [CacheDuration.MASSIVE_VALUE],

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/controller/TokenController.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/controller/TokenController.kt
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.io.Serializable
 import java.util.UUID
-import kotlin.jvm.optionals.getOrNull
 
 @RestController
 @RequestMapping(path = ["/token"], produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -50,10 +49,9 @@ class TokenController(
         log.debug("Receive a request to refresh token for user with id: {}", userId)
 
         try {
-            val userOpt = usuarioService.getUsuarioById(UUID.fromString(userId)).getOrNull()
-            userOpt?.let {
+            usuarioService.getUsuarioById(UUID.fromString(userId))?.let {
                 log.trace("User found, refreshing token for user with id: {}", userId)
-                apiResponse.addData(tokenService.generateTokens(userOpt))
+                apiResponse.addData(tokenService.generateTokens(it))
                 apiResponse.addStatusCode(HttpStatus.OK)
                 log.debug("Deleting refresh token for user with id: {}", userId)
                 redisTemplate.delete("token:refresh:$userId:${jwt.id}").awaitSingle()

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/repository/RolRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/repository/RolRepository.kt
@@ -4,10 +4,9 @@ import io.github.kingg22.api.vacunas.panama.modules.common.dto.IdNombreDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import java.util.Optional
 
 interface RolRepository : JpaRepository<Rol, Short> {
-    fun findByNombreOrId(nombreRol: String?, id: Short?): Optional<Rol>
+    fun findByNombreOrId(nombreRol: String?, id: Short?): Rol?
 
     @Query(
         "SELECT new io.github.kingg22.api.vacunas.panama.modules.common.dto.IdNombreDto(r.id, r.nombre) FROM Rol r ORDER BY r.id",

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/repository/UsuarioRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/repository/UsuarioRepository.kt
@@ -4,11 +4,10 @@ import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.Optional
 import java.util.UUID
 
 interface UsuarioRepository : JpaRepository<Usuario, UUID> {
-    fun findByUsername(username: String?): Optional<Usuario>
+    fun findByUsername(username: String?): Usuario?
 
     @Query(
         "SELECT p.usuario " + "FROM Persona p " +
@@ -21,7 +20,7 @@ interface UsuarioRepository : JpaRepository<Usuario, UUID> {
         @Param("cedula") cedula: String?,
         @Param("pasaporte") pasaporte: String?,
         @Param("correo") correo: String?,
-    ): Optional<Usuario>
+    ): Usuario?
 
     @Query(
         "SELECT f.usuario FROM Fabricante f " + "LEFT JOIN Entidad e ON f.id = e.id " +
@@ -29,8 +28,5 @@ interface UsuarioRepository : JpaRepository<Usuario, UUID> {
             "(:licencia IS NULL OR f.licencia = :licencia) AND " +
             "(:correo IS NULL OR f.correo = :correo)",
     )
-    fun findByLicenciaOrCorreo(
-        @Param("licencia") licencia: String?,
-        @Param("correo") correo: String?,
-    ): Optional<Usuario>
+    fun findByLicenciaOrCorreo(@Param("licencia") licencia: String?, @Param("correo") correo: String?): Usuario?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/FabricanteRegistrationStrategy.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/FabricanteRegistrationStrategy.kt
@@ -29,7 +29,7 @@ class FabricanteRegistrationStrategy(
                 },
             )
 
-        return fabricanteService.getFabricante(licencia).map { fabricante ->
+        return fabricanteService.getFabricante(licencia)?.let { fabricante ->
             when {
                 fabricante.entidad.disabled -> RegistrationError(
                     createApiErrorBuilder {
@@ -47,13 +47,11 @@ class FabricanteRegistrationStrategy(
 
                 else -> RegistrationSuccess(fabricante)
             }
-        }.orElse(
-            RegistrationError(
-                createApiErrorBuilder {
-                    withCode(ApiResponseCode.NOT_FOUND)
-                    withMessage("Fabricante no encontrado")
-                },
-            ),
+        } ?: RegistrationError(
+            createApiErrorBuilder {
+                withCode(ApiResponseCode.NOT_FOUND)
+                withMessage("Fabricante no encontrado")
+            },
         )
     }
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/PersonaRegistrationStrategy.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/PersonaRegistrationStrategy.kt
@@ -35,7 +35,7 @@ class PersonaRegistrationStrategy(
                 },
             )
 
-        return personaService.getPersona(identifier).map { persona ->
+        return personaService.getPersona(identifier)?.let { persona ->
             when {
                 persona.disabled -> RegistrationError(
                     createApiErrorBuilder {
@@ -53,13 +53,11 @@ class PersonaRegistrationStrategy(
 
                 else -> RegistrationSuccess(persona)
             }
-        }.orElse(
-            RegistrationError(
-                createApiErrorBuilder {
-                    withCode(ApiResponseCode.NOT_FOUND)
-                    withMessage("Persona no encontrada")
-                },
-            ),
+        } ?: RegistrationError(
+            createApiErrorBuilder {
+                withCode(ApiResponseCode.NOT_FOUND)
+                withMessage("Persona no encontrada")
+            },
         )
     }
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/ReactiveUserDetailsServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/ReactiveUserDetailsServiceImpl.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.service
 
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
+import io.github.kingg22.api.vacunas.panama.util.monoFromNullable
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService
 import org.springframework.security.core.userdetails.User
@@ -9,7 +10,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import java.util.Optional
 
 /**
  * Service for loading user details during JWT authentication. Extends [ReactiveUserDetailsService] and is used by Spring
@@ -18,10 +18,7 @@ import java.util.Optional
 @Component
 class ReactiveUserDetailsServiceImpl(private val usuarioService: UsuarioService) : ReactiveUserDetailsService {
     override fun findByUsername(username: String): Mono<UserDetails> =
-        Mono.just(usuarioService.getUsuarioByIdentifier(username))
-            .flatMap { optUser: Optional<UsuarioDto> ->
-                optUser.map { Mono.just(it) }.orElseGet { Mono.empty() }
-            }
+        monoFromNullable(usuarioService.getUsuarioByIdentifier(username))
             .switchIfEmpty(Mono.error { UsernameNotFoundException("User not found") })
             .flatMap { user: UsuarioDto ->
                 val roles = user.roles.mapNotNull { it.nombre?.uppercase() }.toTypedArray()

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/RolPermisoServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/RolPermisoServiceImpl.kt
@@ -32,7 +32,7 @@ class RolPermisoServiceImpl(
 
     override fun convertToExistRol(setRolDto: Set<RolDto>): Set<RolDto> = setRolDto
         .mapNotNull {
-            rolRepository.findByNombreOrId(it.nombre, it.id).map { it.toRolDto() }.orElse(null).also { found ->
+            rolRepository.findByNombreOrId(it.nombre, it.id)?.toRolDto().also { found ->
                 if (found == null) log.warn("Rol no encontrado: ${it.nombre ?: it.id}")
             }
         }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/UsuarioService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/UsuarioService.kt
@@ -6,7 +6,6 @@ import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
 import io.github.kingg22.api.vacunas.panama.response.ApiContentResponse
 import org.springframework.security.core.Authentication
-import java.util.Optional
 import java.util.UUID
 
 /**
@@ -20,17 +19,17 @@ interface UsuarioService {
      * Retrieves a user by a given identifier (could be username, email, or ID depending on logic).
      *
      * @param identifier User identifier.
-     * @return Optional containing the user if found.
+     * @return The user if found, otherwise null.
      */
-    fun getUsuarioByIdentifier(identifier: String): Optional<UsuarioDto>
+    fun getUsuarioByIdentifier(identifier: String): UsuarioDto?
 
     /**
      * Retrieves a user by a given unique ID.
      *
      * @param id User ID.
-     * @return Optional containing the user if found.
+     * @return The user if found, otherwise null.
      */
-    fun getUsuarioById(id: UUID): Optional<UsuarioDto>
+    fun getUsuarioById(id: UUID): UsuarioDto?
 
     /**
      * Retrieves the complete profile data for a given user.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/repository/DosisRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/repository/DosisRepository.kt
@@ -6,11 +6,10 @@ import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Dosis
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Vacuna
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.Optional
 import java.util.UUID
 
 interface DosisRepository : JpaRepository<Dosis, UUID> {
-    fun findTopByPacienteAndVacunaOrderByCreatedAtDesc(paciente: Paciente, vacuna: Vacuna): Optional<Dosis>
+    fun findTopByPacienteAndVacunaOrderByCreatedAtDesc(paciente: Paciente, vacuna: Vacuna): Dosis?
 
     fun findAllByPaciente_IdAndVacuna_IdOrderByCreatedAtDesc(paciente: UUID, id: UUID): List<Dosis>
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/util/NullableExt.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/util/NullableExt.kt
@@ -1,0 +1,56 @@
+package io.github.kingg22.api.vacunas.panama.util
+
+import reactor.core.publisher.Mono
+
+/**
+ * Returns the receiver object if it is not null; otherwise, returns the provided alternative.
+ *
+ * @param other The alternative value to return if the receiver object is null.
+ * @return The receiver object if it is not null, otherwise the alternative value.
+ */
+infix fun <T> T?.or(other: T?) = this ?: other
+
+/**
+ * Returns the receiver object if it is not null; otherwise, returns the provided alternative.
+ *
+ * @param other The alternative value to return if the receiver object is null.
+ * @return The receiver object if it is not null, otherwise the alternative value.
+ */
+infix fun <T> T?.or(other: () -> T?) = this ?: other()
+
+/**
+ * Returns the receiver if it is not null; otherwise, returns the specified alternative value.
+ *
+ * @param other The alternative value to return if the receiver is null.
+ * @return The receiver if not null, otherwise the specified alternative value _non null_.
+ */
+infix fun <T> T?.orElse(other: T) = this ?: other
+
+/**
+ * Returns the receiver if it is not null; otherwise, returns the specified alternative value.
+ *
+ * @param other The alternative value to return if the receiver is null.
+ * @return The receiver if not null, otherwise the specified alternative value _non null_.
+ */
+infix fun <T> T?.orElse(other: () -> T) = this ?: other()
+
+/**
+ * Executes the given `presentConsumer` function if the nullable receiver is not null.
+ * Otherwise, executes the `missingAction` function if the receiver is null.
+ *
+ * @param presentConsumer a function to be executed if the receiver is not null.
+ * @param missingAction a function to be executed if the receiver is null.
+ */
+fun <T> T?.ifPresentOrElse(presentConsumer: (T) -> Unit, missingAction: () -> Unit) {
+    if (this != null) presentConsumer(this) else missingAction()
+}
+
+/**
+ * Converts a nullable value into a Reactor Mono.
+ * If the value is non-null, wraps it in a Mono.
+ * If the value is null, it returns an empty Mono.
+ *
+ * @param nullable The nullable value to be converted into a Mono.
+ * @return A Mono containing the value if non-null, or an empty Mono if the value is null.
+ */
+fun <T> monoFromNullable(nullable: T?): Mono<T> = if (nullable != null) Mono.just(nullable) else Mono.empty()


### PR DESCRIPTION
## Resumen por Sourcery

Eliminar el uso de Optional de Java y reemplazarlo con tipos anulables de Kotlin y funciones de extensión

Mejoras:
- Se introdujeron funciones de extensión de manejo de tipos anulables en una nueva clase de utilidad
- Se simplificó el manejo opcional en múltiples implementaciones de servicio

Tareas:
- Versión actualizada a 0.14.1
- Versión de la imagen de docker-compose actualizada

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove usage of Java's Optional and replace with Kotlin nullable types and extension functions

Enhancements:
- Introduced nullable type handling extension functions in a new utility class
- Simplified optional handling across multiple service implementations

Chores:
- Updated version to 0.14.1
- Updated docker-compose image version

</details>