### PR TITLE
perf(data layer): add layer to data persistence to avoid problems with coupling of entity

### DIFF
--- a/.idea/runConfigurations/api_vacunas_panama__build_.xml
+++ b/.idea/runConfigurations/api_vacunas_panama__build_.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="api-vacunas-panama [build]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="build" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 group = "io.github.kingg22"
-version = "0.14.5"
+version = "0.14.6"
 
 java {
     toolchain {
@@ -31,6 +31,7 @@ kotlin {
     jvmToolchain(21)
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")
+        javaParameters.set(true)
     }
 }
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/controller/BulkController.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/controller/BulkController.kt
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.server.reactive.ServerHttpRequest
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController
 class BulkController(private val usuarioService: UsuarioService, private val pacienteService: PacienteService) {
     private val log = logger()
 
-    @Transactional
     @PostMapping("/paciente-usuario-direccion")
     suspend fun createPacienteUsuario(
         @RequestBody @Valid pacienteInputDto: PacienteInputDto,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/common/entity/Entidad.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/common/entity/Entidad.kt
@@ -45,7 +45,7 @@ class Entidad(
     @NotNull
     @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "direccion", nullable = false)
-    var direccion: Direccion,
+    var direccion: Direccion = Direccion.DIRECCION_DEFAULT,
 
     @Size(max = 50)
     @NotNull

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/domain/DireccionModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/domain/DireccionModel.kt
@@ -1,0 +1,31 @@
+package io.github.kingg22.api.vacunas.panama.modules.direccion.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.ProvinciaDto
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+import java.util.UUID
+
+/**
+ * Domain model representing an address in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class DireccionModel(
+    val id: UUID? = null,
+    val descripcion: String,
+    val distrito: DistritoModel,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+) {
+    companion object {
+        val DEFAULT_DIRECCION_MODEL = DireccionModel(
+            descripcion = DireccionDto.DEFAULT_DIRECCION,
+            distrito = DistritoModel(
+                0,
+                "Por registrar",
+                ProvinciaModel(0, ProvinciaDto.DEFAULT_PROVINCIA),
+            ),
+            createdAt = LocalDateTime.now(UTC),
+        )
+    }
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/domain/DistritoModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/domain/DistritoModel.kt
@@ -1,0 +1,6 @@
+package io.github.kingg22.api.vacunas.panama.modules.direccion.domain
+
+/**
+ * Domain model representing a district in the system.
+ */
+data class DistritoModel(val id: Short? = null, val nombre: String, val provincia: ProvinciaModel)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/domain/ProvinciaModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/domain/ProvinciaModel.kt
@@ -1,0 +1,6 @@
+package io.github.kingg22.api.vacunas.panama.modules.direccion.domain
+
+/**
+ * Domain model representing a province in the system.
+ */
+data class ProvinciaModel(val id: Short? = null, val nombre: String)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/dto/DireccionDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/dto/DireccionDto.kt
@@ -2,6 +2,7 @@ package io.github.kingg22.api.vacunas.panama.modules.direccion.dto
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.DireccionModel
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.validation.Valid
@@ -15,6 +16,7 @@ import java.util.UUID
 /** DTO for [io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion] */
 @JvmRecord
 @KonvertTo(Direccion::class)
+@KonvertTo(DireccionModel::class)
 data class DireccionDto(
     val id: UUID? = null,
 
@@ -40,8 +42,8 @@ data class DireccionDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/dto/DistritoDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/dto/DistritoDto.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.DistritoModel
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Distrito
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.validation.Valid
@@ -10,6 +11,7 @@ import java.io.Serializable
 /** DTO for [io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Distrito] */
 @JvmRecord
 @KonvertTo(Distrito::class)
+@KonvertTo(DistritoModel::class)
 data class DistritoDto(
     val id: Short? = null,
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/dto/ProvinciaDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/dto/ProvinciaDto.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.ProvinciaModel
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Provincia
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.validation.constraints.Size
@@ -9,6 +10,7 @@ import java.io.Serializable
 /** DTO for [io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Provincia] */
 @JvmRecord
 @KonvertTo(Provincia::class)
+@KonvertTo(ProvinciaModel::class)
 data class ProvinciaDto(
     val id: Short? = null,
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Direccion.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Direccion.kt
@@ -57,6 +57,9 @@ class Direccion(
     @JoinColumn(name = "distrito", nullable = false)
     var distrito: Distrito,
 ) {
+    override fun toString(): String = Direccion::class.simpleName +
+        "(id=$id, descripcion='$descripcion', createdAt=$createdAt, updatedAt=$updatedAt, distrito=$distrito)"
+
     @KonvertFrom(DireccionModel::class)
     companion object {
         val DIRECCION_DEFAULT = Direccion(

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Direccion.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Direccion.kt
@@ -1,6 +1,10 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.entity
 
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.DireccionModel
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DistritoDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.ProvinciaDto
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -52,4 +56,15 @@ class Direccion(
     @ColumnDefault("0")
     @JoinColumn(name = "distrito", nullable = false)
     var distrito: Distrito,
-)
+) {
+    @KonvertFrom(DireccionModel::class)
+    companion object {
+        val DIRECCION_DEFAULT = Direccion(
+            descripcion = DireccionDto.DEFAULT_DIRECCION,
+            distrito = Distrito(
+                nombre = DistritoDto.DEFAULT_DISTRITO,
+                provincia = Provincia(nombre = ProvinciaDto.DEFAULT_PROVINCIA),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Distrito.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Distrito.kt
@@ -38,6 +38,9 @@ class Distrito(
     @Column(name = "nombre", nullable = false, length = 100)
     var nombre: String,
 ) {
+    override fun toString(): String = Distrito::class.simpleName +
+        "(id=$id, provincia=$provincia, nombre='$nombre')"
+
     @KonvertFrom(DistritoModel::class)
     companion object
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Distrito.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Distrito.kt
@@ -1,6 +1,8 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.entity
 
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.DistritoModel
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DistritoDto
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -35,4 +37,7 @@ class Distrito(
     @NotNull
     @Column(name = "nombre", nullable = false, length = 100)
     var nombre: String,
-)
+) {
+    @KonvertFrom(DistritoModel::class)
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Provincia.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Provincia.kt
@@ -1,6 +1,8 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.entity
 
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.ProvinciaModel
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.ProvinciaDto
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -27,4 +29,7 @@ class Provincia(
     @NotNull
     @Column(name = "nombre", nullable = false, length = 30)
     var nombre: String,
-)
+) {
+    @KonvertFrom(ProvinciaModel::class)
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Provincia.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/entity/Provincia.kt
@@ -30,6 +30,9 @@ class Provincia(
     @Column(name = "nombre", nullable = false, length = 30)
     var nombre: String,
 ) {
+    override fun toString(): String = Provincia::class.simpleName +
+        "(id=$id, nombre='$nombre')"
+
     @KonvertFrom(ProvinciaModel::class)
     companion object
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceService.kt
@@ -1,0 +1,83 @@
+package io.github.kingg22.api.vacunas.panama.modules.direccion.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DistritoDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.ProvinciaDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing addresses.
+ *
+ * This service provides operations related to the persistence of addresses,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface DireccionPersistenceService {
+
+    /**
+     * Finds all districts.
+     *
+     * @return A list of district DTOs.
+     */
+    suspend fun findAllDistritos(): List<DistritoDto>
+
+    /**
+     * Finds all provinces.
+     *
+     * @return A list of province DTOs.
+     */
+    suspend fun findAllProvincias(): List<ProvinciaDto>
+
+    /**
+     * Finds a district by its ID.
+     *
+     * @param id The ID of the district.
+     * @return The district DTO if found, null otherwise.
+     */
+    suspend fun findDistritoById(id: Short): DistritoDto?
+
+    /**
+     * Saves a new address entity.
+     *
+     * @param direccion The address entity to save.
+     * @return The saved address entity.
+     */
+    suspend fun saveDireccion(direccion: Direccion): Direccion
+
+    /**
+     * Finds an address by its ID.
+     *
+     * @param id The ID of the address.
+     * @return The address entity if found, null otherwise.
+     */
+    suspend fun findDireccionById(id: UUID): Direccion?
+
+    /**
+     * Finds addresses by description and district ID.
+     *
+     * @param descripcion The description of the address.
+     * @param distritoId The ID of the district.
+     * @return A list of address entities.
+     */
+    suspend fun findDireccionByDescripcionAndDistritoId(descripcion: String, distritoId: Int): List<Direccion>
+
+    /**
+     * Finds addresses by description and district name.
+     *
+     * @param descripcion The description of the address.
+     * @param distritoNombre The name of the district.
+     * @return A list of address entities.
+     */
+    suspend fun findDireccionByDescripcionAndDistritoNombre(
+        descripcion: String,
+        distritoNombre: String,
+    ): List<Direccion>
+
+    /**
+     * Finds addresses by description starting with a given string.
+     *
+     * @param descripcion The description prefix.
+     * @return A list of address entities.
+     */
+    suspend fun findDireccionByDescripcionStartingWith(descripcion: String): List<Direccion>
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceService.kt
@@ -1,5 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.persistence
 
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DistritoDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.ProvinciaDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
@@ -37,12 +38,12 @@ interface DireccionPersistenceService {
     suspend fun findDistritoById(id: Short): DistritoDto?
 
     /**
-     * Saves a new address entity.
+     * Saves a new address entity using DTO.
      *
-     * @param direccion The address entity to save.
-     * @return The saved address entity.
+     * @param direccionDto The address DTO to save.
+     * @return The saved address DTO.
      */
-    suspend fun saveDireccion(direccion: Direccion): Direccion
+    suspend fun saveDireccion(direccionDto: DireccionDto): DireccionDto
 
     /**
      * Finds an address by its ID.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceService.kt
@@ -59,7 +59,7 @@ interface DireccionPersistenceService {
      * @param distritoId The ID of the district.
      * @return A list of address entities.
      */
-    suspend fun findDireccionByDescripcionAndDistritoId(descripcion: String, distritoId: Int): List<Direccion>
+    suspend fun findDireccionByDescripcionAndDistritoId(descripcion: String, distritoId: Short): List<Direccion>
 
     /**
      * Finds addresses by description and district name.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceServiceImpl.kt
@@ -1,12 +1,16 @@
 package io.github.kingg22.api.vacunas.panama.modules.direccion.persistence
 
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.toDireccion
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
+import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.toDireccionDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.toDistritoDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.extensions.toListDistritoDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.extensions.toListProvinciaDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.DireccionRepository
 import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.DistritoRepository
 import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.ProvinciaRepository
+import io.github.kingg22.api.vacunas.panama.util.logger
 import jakarta.persistence.EntityManager
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -28,6 +32,7 @@ class DireccionPersistenceServiceImpl(
     private val distritoRepository: DistritoRepository,
     private val provinciaRepository: ProvinciaRepository,
 ) : DireccionPersistenceService {
+    private val log = logger()
 
     /**
      * Finds all districts.
@@ -52,19 +57,22 @@ class DireccionPersistenceServiceImpl(
     override suspend fun findDistritoById(id: Short) = distritoRepository.findByIdOrNull(id)?.toDistritoDto()
 
     /**
-     * Saves a new address entity.
+     * Saves a new address entity using DTO.
      *
-     * @param direccion The address entity to save.
-     * @return The saved address entity.
+     * @param direccionDto The address DTO to save.
+     * @return The saved address DTO.
      */
-    override suspend fun saveDireccion(direccion: Direccion): Direccion {
+    override suspend fun saveDireccion(direccionDto: DireccionDto): DireccionDto {
         var direccionSaved: Direccion? = null
         transactionTemplate.execute {
+            log.trace("Saving direccionDTO {}", direccionDto.toString())
+            val direccion = direccionDto.toDireccion()
+            log.trace("Converted direccion {}", direccion.toString())
             entityManager.merge(direccion)
             direccionSaved = direccionRepository.save(direccion)
         }
         checkNotNull(direccionSaved) { "Direccion not saved" }
-        return direccionSaved
+        return direccionSaved.toDireccionDto()
     }
 
     /**

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceServiceImpl.kt
@@ -1,0 +1,106 @@
+package io.github.kingg22.api.vacunas.panama.modules.direccion.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
+import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.toDistritoDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.extensions.toListDistritoDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.extensions.toListProvinciaDto
+import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.DireccionRepository
+import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.DistritoRepository
+import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.ProvinciaRepository
+import jakarta.persistence.EntityManager
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.UUID
+
+/**
+ * Implementation of the DireccionPersistenceService interface.
+ *
+ * This service provides operations related to the persistence of addresses,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class DireccionPersistenceServiceImpl(
+    private val entityManager: EntityManager,
+    private val transactionTemplate: TransactionTemplate,
+    private val direccionRepository: DireccionRepository,
+    private val distritoRepository: DistritoRepository,
+    private val provinciaRepository: ProvinciaRepository,
+) : DireccionPersistenceService {
+
+    /**
+     * Finds all districts.
+     *
+     * @return A list of district DTOs.
+     */
+    override suspend fun findAllDistritos() = distritoRepository.findAll().toListDistritoDto()
+
+    /**
+     * Finds all provinces.
+     *
+     * @return A list of province DTOs.
+     */
+    override suspend fun findAllProvincias() = provinciaRepository.findAll().toListProvinciaDto()
+
+    /**
+     * Finds a district by its ID.
+     *
+     * @param id The ID of the district.
+     * @return The district DTO if found, null otherwise.
+     */
+    override suspend fun findDistritoById(id: Short) = distritoRepository.findByIdOrNull(id)?.toDistritoDto()
+
+    /**
+     * Saves a new address entity.
+     *
+     * @param direccion The address entity to save.
+     * @return The saved address entity.
+     */
+    override suspend fun saveDireccion(direccion: Direccion): Direccion {
+        var direccionSaved: Direccion? = null
+        transactionTemplate.execute {
+            entityManager.merge(direccion)
+            direccionSaved = direccionRepository.save(direccion)
+        }
+        checkNotNull(direccionSaved) { "Direccion not saved" }
+        return direccionSaved
+    }
+
+    /**
+     * Finds an address by its ID.
+     *
+     * @param id The ID of the address.
+     * @return The address entity if found, null otherwise.
+     */
+    override suspend fun findDireccionById(id: UUID) = direccionRepository.findByIdOrNull(id)
+
+    /**
+     * Finds addresses by description and district ID.
+     *
+     * @param descripcion The description of the address.
+     * @param distritoId The ID of the district.
+     * @return A list of address entities.
+     */
+    override suspend fun findDireccionByDescripcionAndDistritoId(descripcion: String, distritoId: Int) =
+        direccionRepository.findDireccionByDescripcionAndDistrito_Id(descripcion, distritoId)
+
+    /**
+     * Finds addresses by description and district name.
+     *
+     * @param descripcion The description of the address.
+     * @param distritoNombre The name of the district.
+     * @return A list of address entities.
+     */
+    override suspend fun findDireccionByDescripcionAndDistritoNombre(descripcion: String, distritoNombre: String) =
+        direccionRepository.findDireccionByDescripcionAndDistrito_Nombre(descripcion, distritoNombre)
+
+    /**
+     * Finds addresses by description starting with a given string.
+     *
+     * @param descripcion The description prefix.
+     * @return A list of address entities.
+     */
+    override suspend fun findDireccionByDescripcionStartingWith(descripcion: String) =
+        direccionRepository.findDireccionByDescripcionStartingWith(descripcion)
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/persistence/DireccionPersistenceServiceImpl.kt
@@ -82,7 +82,7 @@ class DireccionPersistenceServiceImpl(
      * @param distritoId The ID of the district.
      * @return A list of address entities.
      */
-    override suspend fun findDireccionByDescripcionAndDistritoId(descripcion: String, distritoId: Int) =
+    override suspend fun findDireccionByDescripcionAndDistritoId(descripcion: String, distritoId: Short) =
         direccionRepository.findDireccionByDescripcionAndDistrito_Id(descripcion, distritoId)
 
     /**

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/repository/DireccionRepository.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/repository/DireccionRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface DireccionRepository : JpaRepository<Direccion, UUID> {
-    fun findDireccionByDescripcionAndDistrito_Id(descripcion: String? = null, idDistrito: Int): List<Direccion>
+    fun findDireccionByDescripcionAndDistrito_Id(descripcion: String? = null, idDistrito: Short): List<Direccion>
 
     fun findDireccionByDescripcionStartingWith(descripcion: String? = null): List<Direccion>
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionService.kt
@@ -29,7 +29,7 @@ interface DireccionService {
      * Creates and persists a new `Direccion` entity from the given [DireccionDto].
      *
      * @param direccionDto DTO containing address data to persist.
-     * @return The newly created [DireccionDto] entity.
+     * @return The newly created [DireccionDto] representing the saved model.
      */
     suspend fun createDireccion(@Valid direccionDto: DireccionDto): DireccionDto
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionServiceImpl.kt
@@ -2,8 +2,6 @@ package io.github.kingg22.api.vacunas.panama.modules.direccion.service
 
 import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
-import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.toDistrito
-import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.toDireccionDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.persistence.DireccionPersistenceService
 import jakarta.validation.Valid
@@ -35,12 +33,12 @@ class DireccionServiceImpl(private val direccionPersistenceService: DireccionPer
         } ?: getDistritoDefault()
 
         return direccionPersistenceService.saveDireccion(
-            Direccion(
-                descripcion = direccionDto.descripcion,
-                distrito = distritoDto.toDistrito(),
-                createdAt = direccionDto.createdAt,
+            direccionDto.copy(
+                id = null,
+                updatedAt = null,
+                distrito = distritoDto,
             ),
-        ).toDireccionDto()
+        )
     }
 
     suspend fun getDistritoDefault() = direccionPersistenceService.findDistritoById(0)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionServiceImpl.kt
@@ -54,7 +54,7 @@ class DireccionServiceImpl(private val direccionPersistenceService: DireccionPer
         direccionDto.distrito.id?.let { distritoId ->
             direccionPersistenceService.findDireccionByDescripcionAndDistritoId(
                 direccion,
-                distritoId.toInt(),
+                distritoId,
             ).firstOrNull()?.let {
                 return it.toDireccionDto()
             }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/direccion/service/DireccionServiceImpl.kt
@@ -2,69 +2,57 @@ package io.github.kingg22.api.vacunas.panama.modules.direccion.service
 
 import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
-import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DistritoDto
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.toDistrito
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.toDireccionDto
-import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.toDistritoDto
-import io.github.kingg22.api.vacunas.panama.modules.direccion.extensions.toListDistritoDto
-import io.github.kingg22.api.vacunas.panama.modules.direccion.extensions.toListProvinciaDto
-import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.DireccionRepository
-import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.DistritoRepository
-import io.github.kingg22.api.vacunas.panama.modules.direccion.repository.ProvinciaRepository
+import io.github.kingg22.api.vacunas.panama.modules.direccion.persistence.DireccionPersistenceService
 import jakarta.validation.Valid
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class DireccionServiceImpl(
-    private val direccionRepository: DireccionRepository,
-    private val distritoRepository: DistritoRepository,
-    private val provinciaRepository: ProvinciaRepository,
-) : DireccionService {
+class DireccionServiceImpl(private val direccionPersistenceService: DireccionPersistenceService) : DireccionService {
     @Cacheable(
         cacheNames = [CacheDuration.MASSIVE_VALUE],
         key = "'distritosDto'",
         unless = "#result==null or #result.isEmpty()",
     )
-    @Transactional
-    override suspend fun getDistritosDto() = distritoRepository.findAll().toListDistritoDto()
+    override suspend fun getDistritosDto() = direccionPersistenceService.findAllDistritos()
 
     @Cacheable(
         cacheNames = [CacheDuration.MASSIVE_VALUE],
         key = "'provinciasDto'",
         unless = "#result==null or #result.isEmpty()",
     )
-    override suspend fun getProvinciasDto() = provinciaRepository.findAll().toListProvinciaDto()
+    override suspend fun getProvinciasDto() = direccionPersistenceService.findAllProvincias()
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     override suspend fun createDireccion(@Valid direccionDto: DireccionDto): DireccionDto {
-        val distrito = direccionDto.distrito.id?.let {
-            distritoRepository.findById(it).orElseThrow()
-        } ?: getDistritoDefault().toDistrito()
+        val distritoDto = direccionDto.distrito.id?.let {
+            direccionPersistenceService.findDistritoById(it)
+        } ?: getDistritoDefault()
 
-        return direccionRepository.save(
+        return direccionPersistenceService.saveDireccion(
             Direccion(
                 descripcion = direccionDto.descripcion,
-                distrito = distrito,
+                distrito = distritoDto.toDistrito(),
                 createdAt = direccionDto.createdAt,
             ),
         ).toDireccionDto()
     }
 
-    suspend fun getDistritoDefault(): DistritoDto = distritoRepository.findByIdOrNull(0)?.toDistritoDto()
+    suspend fun getDistritoDefault() = direccionPersistenceService.findDistritoById(0)
         ?: throw IllegalStateException("Distrito default not found")
 
     override suspend fun getDireccionByDto(@Valid direccionDto: DireccionDto): DireccionDto? {
-        direccionDto.id?.let { return direccionRepository.findByIdOrNull(it)?.toDireccionDto() }
+        direccionDto.id?.let { return direccionPersistenceService.findDireccionById(it)?.toDireccionDto() }
 
         val direccion = direccionDto.descripcion.takeIf { it.isNotBlank() } ?: return null
 
         direccionDto.distrito.id?.let { distritoId ->
-            direccionRepository.findDireccionByDescripcionAndDistrito_Id(
+            direccionPersistenceService.findDireccionByDescripcionAndDistritoId(
                 direccion,
                 distritoId.toInt(),
             ).firstOrNull()?.let {
@@ -73,7 +61,7 @@ class DireccionServiceImpl(
         }
 
         direccionDto.distrito.nombre.let { distritoNombre ->
-            direccionRepository.findDireccionByDescripcionAndDistrito_Nombre(
+            direccionPersistenceService.findDireccionByDescripcionAndDistritoNombre(
                 direccion,
                 distritoNombre,
             ).firstOrNull()?.let {
@@ -81,10 +69,10 @@ class DireccionServiceImpl(
             }
         }
 
-        direccionRepository.findDireccionByDescripcionStartingWith(direccion.lowercase()).firstOrNull()?.let {
-            return it.toDireccionDto()
-        }
-
-        return null
+        return direccionPersistenceService.findDireccionByDescripcionStartingWith(direccion.lowercase())
+            .firstOrNull()
+            ?.let {
+                return it.toDireccionDto()
+            }
     }
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/domain/DoctorModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/domain/DoctorModel.kt
@@ -1,0 +1,17 @@
+package io.github.kingg22.api.vacunas.panama.modules.doctor.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain model representing a doctor in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class DoctorModel(
+    val id: UUID? = null,
+    val persona: PersonaModel,
+    val idoneidad: String? = null,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/dto/DoctorDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/dto/DoctorDto.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.doctor.domain.DoctorModel
 import io.github.kingg22.api.vacunas.panama.modules.doctor.entity.Doctor
 import io.github.kingg22.api.vacunas.panama.modules.persona.dto.PersonaDto
 import io.mcarle.konvert.api.KonvertTo
@@ -28,6 +29,7 @@ import java.time.ZoneOffset.UTC
         Mapping(target = "idoneidad", expression = "idoneidad ?: \"\""),
     ],
 )
+@KonvertTo(DoctorModel::class)
 data class DoctorDto(
     @field:Valid @param:Valid val persona: PersonaDto,
 
@@ -45,8 +47,8 @@ data class DoctorDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/entity/Doctor.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/entity/Doctor.kt
@@ -1,9 +1,12 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.entity
 
+import io.github.kingg22.api.vacunas.panama.modules.doctor.domain.DoctorModel
 import io.github.kingg22.api.vacunas.panama.modules.doctor.dto.DoctorDto
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
 import io.github.kingg22.api.vacunas.panama.modules.sede.entity.Sede
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.api.Mapping
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -61,4 +64,7 @@ class Doctor(
 
     @Column(name = "updated_at")
     var updatedAt: LocalDateTime? = null,
-)
+) {
+    @KonvertFrom(DoctorModel::class, mappings = [Mapping(target = "idoneidad", expression = "it.idoneidad ?: \"\"")])
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/persistence/DoctorPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/persistence/DoctorPersistenceService.kt
@@ -1,0 +1,22 @@
+package io.github.kingg22.api.vacunas.panama.modules.doctor.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.doctor.entity.Doctor
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing doctors.
+ *
+ * This service provides operations related to the persistence of doctors,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface DoctorPersistenceService {
+
+    /**
+     * Finds a doctor by its ID.
+     *
+     * @param id The UUID of the doctor.
+     * @return The doctor entity if found, null otherwise.
+     */
+    suspend fun findDoctorById(id: UUID): Doctor?
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/persistence/DoctorPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/persistence/DoctorPersistenceService.kt
@@ -10,7 +10,7 @@ import java.util.UUID
  * acting as an intermediate layer between the repositories and the service layer.
  * It encapsulates all JPA-related operations.
  */
-interface DoctorPersistenceService {
+fun interface DoctorPersistenceService {
 
     /**
      * Finds a doctor by its ID.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/persistence/DoctorPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/persistence/DoctorPersistenceServiceImpl.kt
@@ -1,0 +1,25 @@
+package io.github.kingg22.api.vacunas.panama.modules.doctor.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.doctor.repository.DoctorRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Implementation of the DoctorPersistenceService interface.
+ *
+ * This service provides operations related to the persistence of doctors,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class DoctorPersistenceServiceImpl(private val doctorRepository: DoctorRepository) : DoctorPersistenceService {
+
+    /**
+     * Finds a doctor by its ID.
+     *
+     * @param id The UUID of the doctor.
+     * @return The doctor entity if found, null otherwise.
+     */
+    override suspend fun findDoctorById(id: UUID) = doctorRepository.findByIdOrNull(id)
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorService.kt
@@ -1,16 +1,16 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.service
 
-import io.github.kingg22.api.vacunas.panama.modules.doctor.dto.DoctorDto
+import io.github.kingg22.api.vacunas.panama.modules.doctor.domain.DoctorModel
 import java.util.UUID
 
 /** Service interface for managing and retrieving doctor-related information. */
 fun interface DoctorService {
 
     /**
-     * Retrieves a [DoctorDto] by its unique doctor ID.
+     * Retrieves a [DoctorModel] by its unique doctor ID.
      *
      * @param idDoctor UUID of the doctor to retrieve.
      * @return The doctor if found, or null if not.
      */
-    suspend fun getDoctorById(idDoctor: UUID): DoctorDto?
+    suspend fun getDoctorById(idDoctor: UUID): DoctorModel?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorServiceImpl.kt
@@ -1,12 +1,12 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.service
 
 import io.github.kingg22.api.vacunas.panama.modules.doctor.entity.toDoctorDto
-import io.github.kingg22.api.vacunas.panama.modules.doctor.repository.DoctorRepository
-import org.springframework.data.repository.findByIdOrNull
+import io.github.kingg22.api.vacunas.panama.modules.doctor.persistence.DoctorPersistenceService
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class DoctorServiceImpl(private val doctorRepository: DoctorRepository) : DoctorService {
-    override suspend fun getDoctorById(idDoctor: UUID) = doctorRepository.findByIdOrNull(idDoctor)?.toDoctorDto()
+class DoctorServiceImpl(private val doctorPersistenceService: DoctorPersistenceService) : DoctorService {
+    override suspend fun getDoctorById(idDoctor: UUID) =
+        doctorPersistenceService.findDoctorById(idDoctor)?.toDoctorDto()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/doctor/service/DoctorServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.doctor.service
 
+import io.github.kingg22.api.vacunas.panama.modules.doctor.dto.toDoctorModel
 import io.github.kingg22.api.vacunas.panama.modules.doctor.entity.toDoctorDto
 import io.github.kingg22.api.vacunas.panama.modules.doctor.persistence.DoctorPersistenceService
 import org.springframework.stereotype.Service
@@ -8,5 +9,5 @@ import java.util.UUID
 @Service
 class DoctorServiceImpl(private val doctorPersistenceService: DoctorPersistenceService) : DoctorService {
     override suspend fun getDoctorById(idDoctor: UUID) =
-        doctorPersistenceService.findDoctorById(idDoctor)?.toDoctorDto()
+        doctorPersistenceService.findDoctorById(idDoctor)?.toDoctorDto()?.toDoctorModel()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/domain/FabricanteModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/domain/FabricanteModel.kt
@@ -1,0 +1,14 @@
+package io.github.kingg22.api.vacunas.panama.modules.fabricante.domain
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain model representing a vaccine manufacturer.
+ */
+data class FabricanteModel(
+    val id: UUID? = null,
+    val nombre: String,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/dto/FabricanteDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/dto/FabricanteDto.kt
@@ -2,7 +2,10 @@ package io.github.kingg22.api.vacunas.panama.modules.fabricante.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.github.kingg22.api.vacunas.panama.modules.common.dto.EntidadDto
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
+import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.api.Mapping
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.PastOrPresent
@@ -10,9 +13,11 @@ import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import java.io.Serializable
 import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
 
 /** DTO for [io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante]  */
 @JvmRecord
+@KonvertTo(Fabricante::class, [Mapping("licencia", expression = "licencia ?: \"\"")])
 data class FabricanteDto(
     @field:Valid @param:Valid val entidad: EntidadDto,
 
@@ -56,10 +61,10 @@ data class FabricanteDto(
     @param:JsonProperty(value = "created_at")
     @field:PastOrPresent
     @param:PastOrPresent
-    val createdAt: LocalDateTime? = null,
+    val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/persistence/FabricantePersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/persistence/FabricantePersistenceService.kt
@@ -1,0 +1,30 @@
+package io.github.kingg22.api.vacunas.panama.modules.fabricante.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing fabricantes.
+ *
+ * This service provides operations related to the persistence of fabricantes,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface FabricantePersistenceService {
+
+    /**
+     * Finds a fabricante by its licencia.
+     *
+     * @param licencia The licencia of the fabricante.
+     * @return The fabricante entity if found, null otherwise.
+     */
+    suspend fun findByLicencia(licencia: String): Fabricante?
+
+    /**
+     * Finds a fabricante by its user ID.
+     *
+     * @param idUsuario The UUID of the user.
+     * @return The fabricante entity if found, null otherwise.
+     */
+    suspend fun findByUsuarioId(idUsuario: UUID): Fabricante?
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/persistence/FabricantePersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/persistence/FabricantePersistenceServiceImpl.kt
@@ -1,0 +1,33 @@
+package io.github.kingg22.api.vacunas.panama.modules.fabricante.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.repository.FabricanteRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Implementation of the FabricantePersistenceService interface.
+ *
+ * This service provides operations related to the persistence of fabricantes,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class FabricantePersistenceServiceImpl(private val fabricanteRepository: FabricanteRepository) :
+    FabricantePersistenceService {
+
+    /**
+     * Finds a fabricante by its licencia.
+     *
+     * @param licencia The licencia of the fabricante.
+     * @return The fabricante entity if found, null otherwise.
+     */
+    override suspend fun findByLicencia(licencia: String) = fabricanteRepository.findByLicencia(licencia)
+
+    /**
+     * Finds a fabricante by its user ID.
+     *
+     * @param idUsuario The UUID of the user.
+     * @return The fabricante entity if found, null otherwise.
+     */
+    override suspend fun findByUsuarioId(idUsuario: UUID) = fabricanteRepository.findByUsuario_Id(idUsuario)
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/service/FabricanteServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/fabricante/service/FabricanteServiceImpl.kt
@@ -1,15 +1,16 @@
 package io.github.kingg22.api.vacunas.panama.modules.fabricante.service
 
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.toFabricanteDto
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.repository.FabricanteRepository
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.persistence.FabricantePersistenceService
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class FabricanteServiceImpl(private val fabricanteRepository: FabricanteRepository) : FabricanteService {
+class FabricanteServiceImpl(private val fabricantePersistenceService: FabricantePersistenceService) :
+    FabricanteService {
     override suspend fun getFabricante(licencia: String) =
-        fabricanteRepository.findByLicencia(licencia)?.toFabricanteDto()
+        fabricantePersistenceService.findByLicencia(licencia)?.toFabricanteDto()
 
     override suspend fun getFabricanteByUserID(idUser: UUID) =
-        fabricanteRepository.findByUsuario_Id(idUser)?.toFabricanteDto()
+        fabricantePersistenceService.findByUsuarioId(idUser)?.toFabricanteDto()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/domain/PacienteModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/domain/PacienteModel.kt
@@ -1,0 +1,15 @@
+package io.github.kingg22.api.vacunas.panama.modules.paciente.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
+import java.time.LocalDateTime
+
+/**
+ * Domain model representing a patient in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class PacienteModel(
+    val persona: PersonaModel,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+    val identificacionTemporal: String? = null,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/dto/PacienteDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/dto/PacienteDto.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.paciente.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.paciente.domain.PacienteModel
 import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
 import io.github.kingg22.api.vacunas.panama.modules.persona.dto.PersonaDto
 import io.mcarle.konvert.api.KonvertTo
@@ -16,6 +17,7 @@ import java.time.ZoneOffset.UTC
 /** DTO for [io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente] */
 @JvmRecord
 @KonvertTo(value = Paciente::class, mappings = [Mapping("id", ignore = true)])
+@KonvertTo(PacienteModel::class)
 data class PacienteDto(
     @field:Valid @param:Valid
     val persona: PersonaDto,
@@ -44,8 +46,8 @@ data class PacienteDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/dto/PacienteInputDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/dto/PacienteInputDto.kt
@@ -88,8 +88,8 @@ data class PacienteInputDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/entity/Paciente.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/entity/Paciente.kt
@@ -1,8 +1,10 @@
 package io.github.kingg22.api.vacunas.panama.modules.paciente.entity
 
+import io.github.kingg22.api.vacunas.panama.modules.paciente.domain.PacienteModel
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.PacienteDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.ViewPacienteVacunaEnfermedadDto
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
 import jakarta.persistence.Column
 import jakarta.persistence.ColumnResult
@@ -119,4 +121,7 @@ class Paciente(
     @Size(max = 255)
     @Column(name = "identificacion_temporal")
     var identificacionTemporal: String? = null,
-)
+) {
+    @KonvertFrom(PacienteModel::class)
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/entity/Paciente.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/entity/Paciente.kt
@@ -122,6 +122,9 @@ class Paciente(
     @Column(name = "identificacion_temporal")
     var identificacionTemporal: String? = null,
 ) {
+    override fun toString(): String = Paciente::class.simpleName +
+        ": id=$id, persona=$persona, createdAt=$createdAt, updatedAt=$updatedAt, identificacionTemporal=$identificacionTemporal"
+
     @KonvertFrom(PacienteModel::class)
     companion object
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceService.kt
@@ -1,0 +1,80 @@
+package io.github.kingg22.api.vacunas.panama.modules.paciente.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.ViewPacienteVacunaEnfermedadDto
+import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing pacientes.
+ *
+ * This service provides operations related to the persistence of pacientes,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface PacientePersistenceService {
+
+    /**
+     * Finds a paciente by its ID.
+     *
+     * @param id The UUID of the paciente.
+     * @return The paciente entity if found, null otherwise.
+     */
+    suspend fun findPacienteById(id: UUID): Paciente?
+
+    /**
+     * Finds all vaccine-disease records for a paciente.
+     *
+     * @param id The UUID of the paciente.
+     * @param vacuna The UUID of the vaccine (optional).
+     * @return A list of DTOs containing vaccine-disease records.
+     */
+    suspend fun findAllFromViewVacunaEnfermedad(id: UUID, vacuna: UUID? = null): List<ViewPacienteVacunaEnfermedadDto>
+
+    /**
+     * Finds a paciente by its temporary identification.
+     *
+     * @param idTemporal The temporary identification of the paciente.
+     * @return The paciente entity if found, null otherwise.
+     */
+    suspend fun findByIdentificacionTemporal(idTemporal: String?): Paciente?
+
+    /**
+     * Finds a paciente by its persona's cedula.
+     *
+     * @param cedula The cedula of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    suspend fun findByPersonaCedula(cedula: String?): Paciente?
+
+    /**
+     * Finds a paciente by its persona's pasaporte.
+     *
+     * @param pasaporte The pasaporte of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    suspend fun findByPersonaPasaporte(pasaporte: String?): Paciente?
+
+    /**
+     * Finds a paciente by its persona's correo.
+     *
+     * @param correo The correo of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    suspend fun findByPersonaCorreo(correo: String?): Paciente?
+
+    /**
+     * Finds a paciente by its persona's telefono.
+     *
+     * @param telefono The telefono of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    suspend fun findByPersonaTelefono(telefono: String?): Paciente?
+
+    /**
+     * Saves a paciente entity.
+     *
+     * @param paciente The paciente entity to save.
+     * @return The saved paciente entity.
+     */
+    suspend fun savePaciente(paciente: Paciente): Paciente
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceService.kt
@@ -1,5 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.paciente.persistence
 
+import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.PacienteDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.ViewPacienteVacunaEnfermedadDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
 import java.util.UUID
@@ -71,10 +72,10 @@ interface PacientePersistenceService {
     suspend fun findByPersonaTelefono(telefono: String?): Paciente?
 
     /**
-     * Saves a paciente entity.
+     * Saves a paciente entity using DTO.
      *
-     * @param paciente The paciente entity to save.
-     * @return The saved paciente entity.
+     * @param pacienteDto The paciente DTO to save.
+     * @return The saved paciente DTO.
      */
-    suspend fun savePaciente(paciente: Paciente): Paciente
+    suspend fun savePaciente(pacienteDto: PacienteDto): PacienteDto
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceServiceImpl.kt
@@ -1,7 +1,11 @@
 package io.github.kingg22.api.vacunas.panama.modules.paciente.persistence
 
+import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.PacienteDto
+import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.toPaciente
 import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
+import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.toPacienteDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.repository.PacienteRepository
+import io.github.kingg22.api.vacunas.panama.util.logger
 import jakarta.persistence.EntityManager
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -21,6 +25,7 @@ class PacientePersistenceServiceImpl(
     private val transactionTemplate: TransactionTemplate,
     private val pacienteRepository: PacienteRepository,
 ) : PacientePersistenceService {
+    private val log = logger()
 
     /**
      * Finds a paciente by its ID.
@@ -83,18 +88,21 @@ class PacientePersistenceServiceImpl(
     override suspend fun findByPersonaTelefono(telefono: String?) = pacienteRepository.findByPersonaTelefono(telefono)
 
     /**
-     * Saves a paciente entity.
+     * Saves a paciente entity using DTO.
      *
-     * @param paciente The paciente entity to save.
-     * @return The saved paciente entity.
+     * @param pacienteDto The paciente DTO to save.
+     * @return The saved paciente DTO.
      */
-    override suspend fun savePaciente(paciente: Paciente): Paciente {
+    override suspend fun savePaciente(pacienteDto: PacienteDto): PacienteDto {
         var savedPaciente: Paciente? = null
         transactionTemplate.execute {
+            log.trace("Saving pacienteDTO {}", pacienteDto)
+            val paciente = pacienteDto.toPaciente()
+            log.trace("Converted paciente {}", paciente)
             entityManager.persist(paciente)
             savedPaciente = paciente
         }
         checkNotNull(savedPaciente) { "Paciente not saved" }
-        return savedPaciente
+        return savedPaciente.toPacienteDto()
     }
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/persistence/PacientePersistenceServiceImpl.kt
@@ -1,0 +1,100 @@
+package io.github.kingg22.api.vacunas.panama.modules.paciente.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
+import io.github.kingg22.api.vacunas.panama.modules.paciente.repository.PacienteRepository
+import jakarta.persistence.EntityManager
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.UUID
+
+/**
+ * Implementation of the PacientePersistenceService interface.
+ *
+ * This service provides operations related to the persistence of pacientes,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class PacientePersistenceServiceImpl(
+    private val entityManager: EntityManager,
+    private val transactionTemplate: TransactionTemplate,
+    private val pacienteRepository: PacienteRepository,
+) : PacientePersistenceService {
+
+    /**
+     * Finds a paciente by its ID.
+     *
+     * @param id The UUID of the paciente.
+     * @return The paciente entity if found, null otherwise.
+     */
+    override suspend fun findPacienteById(id: UUID) = pacienteRepository.findByIdOrNull(id)
+
+    /**
+     * Finds all vaccine-disease records for a paciente.
+     *
+     * @param id The UUID of the paciente.
+     * @param vacuna The UUID of the vaccine (optional).
+     * @return A list of DTOs containing vaccine-disease records.
+     */
+    override suspend fun findAllFromViewVacunaEnfermedad(id: UUID, vacuna: UUID?) =
+        pacienteRepository.findAllFromViewVacunaEnfermedad(id, vacuna)
+
+    /**
+     * Finds a paciente by its temporary identification.
+     *
+     * @param idTemporal The temporary identification of the paciente.
+     * @return The paciente entity if found, null otherwise.
+     */
+    override suspend fun findByIdentificacionTemporal(idTemporal: String?) =
+        pacienteRepository.findByIdentificacionTemporal(idTemporal)
+
+    /**
+     * Finds a paciente by its persona's cedula.
+     *
+     * @param cedula The cedula of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    override suspend fun findByPersonaCedula(cedula: String?) = pacienteRepository.findByPersonaCedula(cedula)
+
+    /**
+     * Finds a paciente by its persona's pasaporte.
+     *
+     * @param pasaporte The pasaporte of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    override suspend fun findByPersonaPasaporte(pasaporte: String?) =
+        pacienteRepository.findByPersonaPasaporte(pasaporte)
+
+    /**
+     * Finds a paciente by its persona's correo.
+     *
+     * @param correo The correo of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    override suspend fun findByPersonaCorreo(correo: String?) = pacienteRepository.findByPersonaCorreo(correo)
+
+    /**
+     * Finds a paciente by its persona's telefono.
+     *
+     * @param telefono The telefono of the persona.
+     * @return The paciente entity if found, null otherwise.
+     */
+    override suspend fun findByPersonaTelefono(telefono: String?) = pacienteRepository.findByPersonaTelefono(telefono)
+
+    /**
+     * Saves a paciente entity.
+     *
+     * @param paciente The paciente entity to save.
+     * @return The saved paciente entity.
+     */
+    override suspend fun savePaciente(paciente: Paciente): Paciente {
+        var savedPaciente: Paciente? = null
+        transactionTemplate.execute {
+            entityManager.persist(paciente)
+            savedPaciente = paciente
+        }
+        checkNotNull(savedPaciente) { "Paciente not saved" }
+        return savedPaciente
+    }
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/service/PacienteService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/service/PacienteService.kt
@@ -1,8 +1,8 @@
 package io.github.kingg22.api.vacunas.panama.modules.paciente.service
 
+import io.github.kingg22.api.vacunas.panama.modules.paciente.domain.PacienteModel
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.PacienteDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.ViewPacienteVacunaEnfermedadDto
-import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
 import io.github.kingg22.api.vacunas.panama.response.ApiContentResponse
 import java.util.UUID
 
@@ -12,7 +12,7 @@ import java.util.UUID
  */
 interface PacienteService {
     /**
-     * Creates a new `Paciente` and associated user if validation is successful.
+     * Creates a new `PacienteModel` and associated user if validation is successful.
      *
      * @param pacienteDto DTO containing the patient information to create.
      * @return [ApiContentResponse] with creation result and metadata.
@@ -28,13 +28,12 @@ interface PacienteService {
     suspend fun getPacienteDtoById(id: UUID): PacienteDto?
 
     /**
-     * Retrieves a [PacienteDto] by its unique ID.
+     * Retrieves a [PacienteModel] by its unique ID.
      *
      * @param idPaciente UUID of the patient.
-     * @return [PacienteDto] if found, or null if not.
+     * @return [PacienteModel] if found, or null if not.
      */
-    @Deprecated("Use DTO instead", replaceWith = ReplaceWith("getPacienteDtoById(idPaciente)"))
-    suspend fun getPacienteById(idPaciente: UUID): Paciente?
+    suspend fun getPacienteById(idPaciente: UUID): PacienteModel?
 
     /**
      * Retrieves a list of vaccines and diseases linked to the given patient.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/service/PacienteServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/paciente/service/PacienteServiceImpl.kt
@@ -4,6 +4,7 @@ import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.toDireccion
 import io.github.kingg22.api.vacunas.panama.modules.direccion.service.DireccionService
 import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.PacienteDto
+import io.github.kingg22.api.vacunas.panama.modules.paciente.dto.toPacienteModel
 import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
 import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.toPacienteDto
 import io.github.kingg22.api.vacunas.panama.modules.paciente.persistence.PacientePersistenceService
@@ -74,8 +75,8 @@ class PacienteServiceImpl(
 
     override suspend fun getPacienteDtoById(id: UUID) = pacientePersistenceService.findPacienteById(id)?.toPacienteDto()
 
-    @Deprecated("Use DTO instead", replaceWith = ReplaceWith("getPacienteDtoById(idPaciente)"))
-    override suspend fun getPacienteById(idPaciente: UUID) = pacientePersistenceService.findPacienteById(idPaciente)
+    override suspend fun getPacienteById(idPaciente: UUID) =
+        pacientePersistenceService.findPacienteById(idPaciente)?.toPacienteDto()?.toPacienteModel()
 
     @Cacheable(cacheNames = [CacheDuration.CACHE_VALUE], key = "'view_vacuna_enfermedad'.concat(#id)")
     override suspend fun getViewVacunaEnfermedad(id: UUID) =

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/domain/PersonaModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/domain/PersonaModel.kt
@@ -1,0 +1,25 @@
+package io.github.kingg22.api.vacunas.panama.modules.persona.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.DireccionModel
+import io.github.kingg22.api.vacunas.panama.modules.usuario.domain.UsuarioModel
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Domain model representing a person in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class PersonaModel(
+    val id: UUID? = null,
+    val nombre: String? = null,
+    val nombre2: String? = null,
+    val apellido1: String? = null,
+    val apellido2: String? = null,
+    val correo: String? = null,
+    val telefono: String? = null,
+    val fechaNacimiento: LocalDate? = null,
+    val cedula: String? = null,
+    val pasaporte: String? = null,
+    val direccion: DireccionModel? = null,
+    val usuario: UsuarioModel? = null,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/dto/PersonaDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/dto/PersonaDto.kt
@@ -2,6 +2,7 @@ package io.github.kingg22.api.vacunas.panama.modules.persona.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.github.kingg22.api.vacunas.panama.modules.direccion.dto.DireccionDto
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
 import io.mcarle.konvert.api.KonvertTo
@@ -26,6 +27,7 @@ import java.util.UUID
  */
 @JvmRecord
 @KonvertTo(Persona::class, mappings = [Mapping(target = "estado", expression = "estado ?: PersonaDto.DEFAULT_ESTADO")])
+@KonvertTo(PersonaModel::class)
 data class PersonaDto(
     val id: UUID? = null,
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/entity/Persona.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/entity/Persona.kt
@@ -1,9 +1,12 @@
 package io.github.kingg22.api.vacunas.panama.modules.persona.entity
 
 import io.github.kingg22.api.vacunas.panama.modules.direccion.entity.Direccion
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
 import io.github.kingg22.api.vacunas.panama.modules.persona.dto.PersonaDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.api.Mapping
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -62,7 +65,7 @@ class Persona(
     @NotNull
     @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "direccion", nullable = false)
-    var direccion: Direccion,
+    var direccion: Direccion = Direccion.DIRECCION_DEFAULT,
 
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "usuario")
@@ -97,4 +100,17 @@ class Persona(
     @Size(max = 254)
     @Column(name = "correo", length = 254)
     var correo: String? = null,
-)
+) {
+    @KonvertFrom(
+        PersonaModel::class,
+        mappings = [
+            Mapping(
+                "fechaNacimiento",
+                expression =
+                "it.fechaNacimiento?.let { f -> java.time.LocalDateTime.from(f.atStartOfDay(java.time.ZoneOffset.UTC)) }",
+            ),
+            Mapping("direccion", ignore = true),
+        ],
+    )
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/entity/Persona.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/entity/Persona.kt
@@ -101,6 +101,9 @@ class Persona(
     @Column(name = "correo", length = 254)
     var correo: String? = null,
 ) {
+    override fun toString(): String = Persona::class.simpleName +
+        " id: $id, nombre: $nombre, apellido1: $apellido1, apellido2: $apellido2, cedula: $cedula, direccion: $direccion, estado: $estado, fechaNacimiento: $fechaNacimiento, pasaporte: $pasaporte, telefono: $telefono, usuario: $usuario, correo: $correo, sexo: $sexo, edad: $edad"
+
     @KonvertFrom(
         PersonaModel::class,
         mappings = [

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/persistence/PersonaPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/persistence/PersonaPersistenceService.kt
@@ -1,0 +1,40 @@
+package io.github.kingg22.api.vacunas.panama.modules.persona.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing personas.
+ *
+ * This service provides operations related to the persistence of personas,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface PersonaPersistenceService {
+
+    /**
+     * Finds a persona by its cedula, pasaporte, or correo.
+     *
+     * @param cedula The cedula of the persona.
+     * @param pasaporte The pasaporte of the persona.
+     * @param correo The correo of the persona.
+     * @return The persona entity if found, null otherwise.
+     */
+    suspend fun findByCedulaOrPasaporteOrCorreo(cedula: String?, pasaporte: String?, correo: String?): Persona?
+
+    /**
+     * Finds a persona by its user ID.
+     *
+     * @param id The UUID of the user.
+     * @return The persona entity if found, null otherwise.
+     */
+    suspend fun findByUsuarioId(id: UUID): Persona?
+
+    /**
+     * Finds a persona by its username.
+     *
+     * @param username The username of the user.
+     * @return The persona entity if found, null otherwise.
+     */
+    suspend fun findByUsuarioUsername(username: String): Persona?
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/persistence/PersonaPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/persistence/PersonaPersistenceServiceImpl.kt
@@ -1,0 +1,43 @@
+package io.github.kingg22.api.vacunas.panama.modules.persona.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.persona.repository.PersonaRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Implementation of the PersonaPersistenceService interface.
+ *
+ * This service provides operations related to the persistence of personas,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class PersonaPersistenceServiceImpl(private val personaRepository: PersonaRepository) : PersonaPersistenceService {
+
+    /**
+     * Finds a persona by its cedula, pasaporte, or correo.
+     *
+     * @param cedula The cedula of the persona.
+     * @param pasaporte The pasaporte of the persona.
+     * @param correo The correo of the persona.
+     * @return The persona entity if found, null otherwise.
+     */
+    override suspend fun findByCedulaOrPasaporteOrCorreo(cedula: String?, pasaporte: String?, correo: String?) =
+        personaRepository.findByCedulaOrPasaporteOrCorreo(cedula, pasaporte, correo)
+
+    /**
+     * Finds a persona by its user ID.
+     *
+     * @param id The UUID of the user.
+     * @return The persona entity if found, null otherwise.
+     */
+    override suspend fun findByUsuarioId(id: UUID) = personaRepository.findByUsuario_Id(id)
+
+    /**
+     * Finds a persona by its username.
+     *
+     * @param username The username of the user.
+     * @return The persona entity if found, null otherwise.
+     */
+    override suspend fun findByUsuarioUsername(username: String) = personaRepository.findByUsuario_Username(username)
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaService.kt
@@ -1,24 +1,20 @@
 package io.github.kingg22.api.vacunas.panama.modules.persona.service
 
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
 import io.github.kingg22.api.vacunas.panama.modules.persona.dto.PersonaDto
-import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
 import java.util.UUID
 
 /** Service interface for managing and retrieving persona-related information. */
 interface PersonaService {
     /**
-     * Retrieves a [Persona] entity by an identifier
+     * Retrieves a [PersonaModel] by an identifier
      * (maybe can be [PersonaDto.cedula], [PersonaDto.pasaporte], [PersonaDto.correo] or `PersonaDto.usuario.username`).
      *
-     * @param identifier UUID of the persona to retrieve.
+     * @param identifier String identifier of the persona to retrieve.
      * @return The persona if found, or null if not.
      * @see io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto.username
      */
-    @Deprecated(
-        message = "This function be change to use DTO when jooq is set as ORM",
-        replaceWith = ReplaceWith("getPersonaDto(identifier)"),
-    )
-    suspend fun getPersona(identifier: String): Persona?
+    suspend fun getPersona(identifier: String): PersonaModel?
 
     /**
      * Retrieves a [PersonaDto] associated with the specified user ID.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
@@ -11,10 +11,6 @@ import java.util.UUID
 
 @Service
 class PersonaServiceImpl(private val personaPersistenceService: PersonaPersistenceService) : PersonaService {
-    @Deprecated(
-        "This function be change to use DTO when jooq is set as ORM",
-        replaceWith = ReplaceWith("getPersonaDto(identifier)"),
-    )
     override suspend fun getPersona(identifier: @NotNull String): PersonaModel? {
         val result = formatToSearch(identifier)
         val personaOpt = personaPersistenceService.findByCedulaOrPasaporteOrCorreo(

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.persona.service
 
-import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
+import io.github.kingg22.api.vacunas.panama.modules.persona.dto.toPersonaModel
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.toPersonaDto
 import io.github.kingg22.api.vacunas.panama.modules.persona.persistence.PersonaPersistenceService
 import io.github.kingg22.api.vacunas.panama.util.FormatterUtil.formatToSearch
@@ -14,14 +15,16 @@ class PersonaServiceImpl(private val personaPersistenceService: PersonaPersisten
         "This function be change to use DTO when jooq is set as ORM",
         replaceWith = ReplaceWith("getPersonaDto(identifier)"),
     )
-    override suspend fun getPersona(identifier: @NotNull String): Persona? {
+    override suspend fun getPersona(identifier: @NotNull String): PersonaModel? {
         val result = formatToSearch(identifier)
         val personaOpt = personaPersistenceService.findByCedulaOrPasaporteOrCorreo(
             result.cedula,
             result.pasaporte,
             result.correo,
         )
-        return personaOpt ?: personaPersistenceService.findByUsuarioUsername(identifier)
+        return (personaOpt ?: personaPersistenceService.findByUsuarioUsername(identifier))
+            ?.toPersonaDto()
+            ?.toPersonaModel()
     }
 
     override suspend fun getPersonaByUserID(idUser: @NotNull UUID) =

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/persona/service/PersonaServiceImpl.kt
@@ -2,28 +2,28 @@ package io.github.kingg22.api.vacunas.panama.modules.persona.service
 
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.toPersonaDto
-import io.github.kingg22.api.vacunas.panama.modules.persona.repository.PersonaRepository
+import io.github.kingg22.api.vacunas.panama.modules.persona.persistence.PersonaPersistenceService
 import io.github.kingg22.api.vacunas.panama.util.FormatterUtil.formatToSearch
 import jakarta.validation.constraints.NotNull
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class PersonaServiceImpl(private val personaRepository: PersonaRepository) : PersonaService {
+class PersonaServiceImpl(private val personaPersistenceService: PersonaPersistenceService) : PersonaService {
     @Deprecated(
         "This function be change to use DTO when jooq is set as ORM",
         replaceWith = ReplaceWith("getPersonaDto(identifier)"),
     )
     override suspend fun getPersona(identifier: @NotNull String): Persona? {
         val result = formatToSearch(identifier)
-        val personaOpt = this.personaRepository.findByCedulaOrPasaporteOrCorreo(
+        val personaOpt = personaPersistenceService.findByCedulaOrPasaporteOrCorreo(
             result.cedula,
             result.pasaporte,
             result.correo,
         )
-        return personaOpt ?: personaRepository.findByUsuario_Username(identifier)
+        return personaOpt ?: personaPersistenceService.findByUsuarioUsername(identifier)
     }
 
     override suspend fun getPersonaByUserID(idUser: @NotNull UUID) =
-        personaRepository.findByUsuario_Id(idUser)?.toPersonaDto()
+        personaPersistenceService.findByUsuarioId(idUser)?.toPersonaDto()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/domain/SedeModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/domain/SedeModel.kt
@@ -1,0 +1,18 @@
+package io.github.kingg22.api.vacunas.panama.modules.sede.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.direccion.domain.DireccionModel
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain model representing a sede (location) in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class SedeModel(
+    val id: UUID? = null,
+    val nombre: String,
+    val dependencia: String? = null,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+    val direccion: DireccionModel? = null,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/dto/SedeDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/dto/SedeDto.kt
@@ -2,6 +2,7 @@ package io.github.kingg22.api.vacunas.panama.modules.sede.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.github.kingg22.api.vacunas.panama.modules.common.dto.EntidadDto
+import io.github.kingg22.api.vacunas.panama.modules.sede.domain.SedeModel
 import io.github.kingg22.api.vacunas.panama.modules.sede.entity.Sede
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
@@ -15,6 +16,17 @@ import java.time.ZoneOffset.UTC
 /** DTO for [io.github.kingg22.api.vacunas.panama.modules.sede.entity.Sede] */
 @JvmRecord
 @KonvertTo(Sede::class, mappings = [Mapping("id", ignore = true)])
+@KonvertTo(
+    SedeModel::class,
+    mappings = [
+        Mapping(
+            "nombre",
+            expression =
+            "entidad.nombre ?: io.github.kingg22.api.vacunas.panama.modules.common.dto.EntidadDto.DEFAULT_NOMBRE",
+        ),
+        Mapping("dependencia", source = "entidad.dependencia"),
+    ],
+)
 data class SedeDto(
     @field:Valid @param:Valid val entidad: EntidadDto,
 
@@ -28,8 +40,8 @@ data class SedeDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/entity/Sede.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/entity/Sede.kt
@@ -1,8 +1,11 @@
 package io.github.kingg22.api.vacunas.panama.modules.sede.entity
 
 import io.github.kingg22.api.vacunas.panama.modules.common.entity.Entidad
+import io.github.kingg22.api.vacunas.panama.modules.sede.domain.SedeModel
 import io.github.kingg22.api.vacunas.panama.modules.sede.dto.SedeDto
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.api.Mapping
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -53,4 +56,15 @@ class Sede(
 
     @Column(name = "updated_at")
     var updatedAt: LocalDateTime? = null,
-)
+) {
+    @KonvertFrom(
+        SedeModel::class,
+        mappings = [
+            Mapping(
+                "entidad",
+                expression = "io.github.kingg22.api.vacunas.panama.modules.common.entity.Entidad(nombre = it.nombre)",
+            ),
+        ],
+    )
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/persistence/SedePersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/persistence/SedePersistenceService.kt
@@ -1,0 +1,30 @@
+package io.github.kingg22.api.vacunas.panama.modules.sede.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.common.dto.UUIDNombreDto
+import io.github.kingg22.api.vacunas.panama.modules.sede.entity.Sede
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing sedes.
+ *
+ * This service provides operations related to the persistence of sedes,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface SedePersistenceService {
+
+    /**
+     * Finds a sede by its ID.
+     *
+     * @param id The UUID of the sede.
+     * @return The sede entity if found, null otherwise.
+     */
+    suspend fun findSedeById(id: UUID): Sede?
+
+    /**
+     * Finds all sedes with their IDs and names.
+     *
+     * @return A list of DTOs containing sede ID and name.
+     */
+    suspend fun findAllIdAndNombre(): List<UUIDNombreDto>
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/persistence/SedePersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/persistence/SedePersistenceServiceImpl.kt
@@ -1,0 +1,32 @@
+package io.github.kingg22.api.vacunas.panama.modules.sede.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.sede.repository.SedeRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * Implementation of the SedePersistenceService interface.
+ *
+ * This service provides operations related to the persistence of sedes,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class SedePersistenceServiceImpl(private val sedeRepository: SedeRepository) : SedePersistenceService {
+
+    /**
+     * Finds a sede by its ID.
+     *
+     * @param id The UUID of the sede.
+     * @return The sede entity if found, null otherwise.
+     */
+    override suspend fun findSedeById(id: UUID) = sedeRepository.findByIdOrNull(id)
+
+    /**
+     * Finds all sedes with their IDs and names.
+     *
+     * @return A list of DTOs containing sede ID and name.
+     */
+    override suspend fun findAllIdAndNombre() = sedeRepository.findAllIdAndNombre()
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeService.kt
@@ -1,8 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.sede.service
 
 import io.github.kingg22.api.vacunas.panama.modules.common.dto.UUIDNombreDto
-import io.github.kingg22.api.vacunas.panama.modules.sede.dto.SedeDto
-import io.github.kingg22.api.vacunas.panama.modules.sede.entity.Sede
+import io.github.kingg22.api.vacunas.panama.modules.sede.domain.SedeModel
 import java.util.UUID
 
 /**
@@ -18,11 +17,10 @@ interface SedeService {
     suspend fun getIdNombreSedes(): List<UUIDNombreDto>
 
     /**
-     * Retrieves the details of a `Sede` entity based on its unique identifier.
+     * Retrieves the details of a `Sede` model based on its unique identifier.
      *
      * @param id the unique identifier of the `Sede` to retrieve
-     * @return a [SedeDto] containing the details of the `Sede`, or null if no found.
+     * @return a [SedeModel] containing the details of the `Sede`, or null if not found.
      */
-    @Deprecated("Use DTO instead")
-    suspend fun getSedeById(id: UUID): Sede?
+    suspend fun getSedeById(id: UUID): SedeModel?
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeServiceImpl.kt
@@ -1,21 +1,20 @@
 package io.github.kingg22.api.vacunas.panama.modules.sede.service
 
 import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
-import io.github.kingg22.api.vacunas.panama.modules.sede.repository.SedeRepository
+import io.github.kingg22.api.vacunas.panama.modules.sede.persistence.SedePersistenceService
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class SedeServiceImpl(private val sedeRepository: SedeRepository) : SedeService {
+class SedeServiceImpl(private val sedePersistenceService: SedePersistenceService) : SedeService {
     @Deprecated("Use DTO instead")
-    override suspend fun getSedeById(id: UUID) = sedeRepository.findByIdOrNull(id)
+    override suspend fun getSedeById(id: UUID) = sedePersistenceService.findSedeById(id)
 
     @Cacheable(
         cacheNames = [CacheDuration.MASSIVE_VALUE],
         key = "'sedesNombre'",
         unless = "#result==null or #result.isEmpty()",
     )
-    override suspend fun getIdNombreSedes() = sedeRepository.findAllIdAndNombre()
+    override suspend fun getIdNombreSedes() = sedePersistenceService.findAllIdAndNombre()
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/sede/service/SedeServiceImpl.kt
@@ -1,6 +1,8 @@
 package io.github.kingg22.api.vacunas.panama.modules.sede.service
 
 import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
+import io.github.kingg22.api.vacunas.panama.modules.sede.dto.toSedeModel
+import io.github.kingg22.api.vacunas.panama.modules.sede.entity.toSedeDto
 import io.github.kingg22.api.vacunas.panama.modules.sede.persistence.SedePersistenceService
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
@@ -8,8 +10,7 @@ import java.util.UUID
 
 @Service
 class SedeServiceImpl(private val sedePersistenceService: SedePersistenceService) : SedeService {
-    @Deprecated("Use DTO instead")
-    override suspend fun getSedeById(id: UUID) = sedePersistenceService.findSedeById(id)
+    override suspend fun getSedeById(id: UUID) = sedePersistenceService.findSedeById(id)?.toSedeDto()?.toSedeModel()
 
     @Cacheable(
         cacheNames = [CacheDuration.MASSIVE_VALUE],

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/domain/UsuarioModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/domain/UsuarioModel.kt
@@ -1,0 +1,16 @@
+package io.github.kingg22.api.vacunas.panama.modules.usuario.domain
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain model representing a user in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class UsuarioModel(
+    val id: UUID? = null,
+    val username: String? = null,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+    val disabled: Boolean = true,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/PermisoDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/PermisoDto.kt
@@ -30,8 +30,8 @@ data class PermisoDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/RolDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/RolDto.kt
@@ -1,7 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RolDto.Companion.DEFAULT_ROL
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
@@ -16,7 +15,7 @@ import java.time.ZoneOffset.UTC
 /**
  * DTO for [io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol]
  *
- * _Warning_: [RolDto.toRol] include a default value ([DEFAULT_ROL]) for [RolDto.nombre] if it is null.
+ * _Warning_: [RolDto.toRol] include a default value ([RolDto.Companion.DEFAULT_ROL]) for [RolDto.nombre] if it is null.
  */
 @JvmRecord
 @KonvertTo(Rol::class, mappings = [Mapping("nombre", expression = "nombre ?: RolDto.DEFAULT_ROL")])

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/RolDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/RolDto.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RolDto.Companion.DEFAULT_ROL
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
@@ -38,8 +39,8 @@ data class RolDto(
     @field:PastOrPresent(message = "La fecha de creación no puede ser futura")
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @param:JsonProperty(value = "updated_at")
-    @field:JsonProperty(value = "updated_at")
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @param:PastOrPresent(message = "La fecha de actualización no puede ser futura")
     @field:PastOrPresent(message = "La fecha de actualización no puede ser futura")
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/UsuarioDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/dto/UsuarioDto.kt
@@ -2,6 +2,7 @@ package io.github.kingg22.api.vacunas.panama.modules.usuario.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.kingg22.api.vacunas.panama.modules.usuario.domain.UsuarioModel
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
@@ -22,6 +23,7 @@ import java.util.UUID
         Mapping("fabricante", ignore = true), Mapping("persona", ignore = true),
     ],
 )
+@KonvertTo(UsuarioModel::class)
 data class UsuarioDto(
     val id: UUID? = null,
 
@@ -37,12 +39,12 @@ data class UsuarioDto(
     @field:JsonProperty(value = "created_at")
     val createdAt: LocalDateTime = LocalDateTime.now(UTC),
 
-    @param:JsonProperty(value = "updated_at")
-    @field:JsonProperty(value = "updated_at")
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     val updatedAt: LocalDateTime? = null,
 
-    @param:JsonProperty(value = "last_used")
-    @field:JsonProperty(value = "last_used")
+    @param:JsonProperty(value = "last_used", access = JsonProperty.Access.READ_ONLY)
+    @field:JsonProperty(value = "last_used", access = JsonProperty.Access.READ_ONLY)
     val lastUsed: LocalDateTime? = null,
 
     @param:NotEmpty(message = "Los roles no puede estar vacíos")

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/entity/Usuario.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/entity/Usuario.kt
@@ -3,7 +3,9 @@ package io.github.kingg22.api.vacunas.panama.modules.usuario.entity
 import com.fasterxml.jackson.annotation.JsonManagedReference
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.github.kingg22.api.vacunas.panama.modules.usuario.domain.UsuarioModel
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
+import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
 import jakarta.persistence.Column
@@ -86,4 +88,7 @@ class Usuario(
 
     @OneToOne(mappedBy = "usuario", fetch = FetchType.EAGER)
     var persona: Persona? = null,
-)
+) {
+    @KonvertFrom(UsuarioModel::class, mappings = [Mapping("clave", constant = "\"\"")])
+    companion object
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceService.kt
@@ -1,9 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.persistence
 
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
-import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RolDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
-import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
 import java.util.UUID
 
@@ -63,17 +61,17 @@ interface UsuarioPersistenceService {
      * Creates a new user entity with the given DTO and associates it with the given persona or fabricante.
      *
      * @param usuarioDto The DTO containing the user information.
-     * @param persona The persona entity to associate with the user (optional).
-     * @param fabricante The fabricante entity to associate with the user (optional).
+     * @param personaId The persona entity to associate with the user (optional).
+     * @param fabricanteId The fabricante entity to associate with the user (optional).
      * @param encodedPassword The encoded password for the user.
      * @param roles The set of roles for the user.
      * @return The created user entity.
      */
     suspend fun createUser(
         usuarioDto: UsuarioDto,
-        persona: Persona? = null,
-        fabricante: Fabricante? = null,
+        personaId: UUID? = null,
+        fabricanteId: UUID? = null,
         encodedPassword: String,
-        roles: MutableSet<Rol>,
+        roles: Set<RolDto>,
     ): Usuario
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceService.kt
@@ -1,0 +1,57 @@
+package io.github.kingg22.api.vacunas.panama.modules.usuario.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing users.
+ *
+ * This service provides operations related to the persistence of users,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface UsuarioPersistenceService {
+
+    /**
+     * Finds a user by its ID.
+     *
+     * @param id The UUID of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    suspend fun findUsuarioById(id: UUID): Usuario?
+
+    /**
+     * Finds a user by its username.
+     *
+     * @param username The username of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    suspend fun findByUsername(username: String?): Usuario?
+
+    /**
+     * Finds a user by its cedula, pasaporte, or correo.
+     *
+     * @param cedula The cedula of the user.
+     * @param pasaporte The pasaporte of the user.
+     * @param correo The correo of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    suspend fun findByCedulaOrPasaporteOrCorreo(cedula: String?, pasaporte: String?, correo: String?): Usuario?
+
+    /**
+     * Finds a user by its licencia or correo.
+     *
+     * @param licencia The licencia of the user.
+     * @param correo The correo of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    suspend fun findByLicenciaOrCorreo(licencia: String?, correo: String?): Usuario?
+
+    /**
+     * Saves a user entity.
+     *
+     * @param usuario The user entity to save.
+     * @return The saved user entity.
+     */
+    suspend fun saveUsuario(usuario: Usuario): Usuario
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceService.kt
@@ -1,5 +1,9 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.persistence
 
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
+import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
+import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
 import java.util.UUID
 
@@ -54,4 +58,22 @@ interface UsuarioPersistenceService {
      * @return The saved user entity.
      */
     suspend fun saveUsuario(usuario: Usuario): Usuario
+
+    /**
+     * Creates a new user entity with the given DTO and associates it with the given persona or fabricante.
+     *
+     * @param usuarioDto The DTO containing the user information.
+     * @param persona The persona entity to associate with the user (optional).
+     * @param fabricante The fabricante entity to associate with the user (optional).
+     * @param encodedPassword The encoded password for the user.
+     * @param roles The set of roles for the user.
+     * @return The created user entity.
+     */
+    suspend fun createUser(
+        usuarioDto: UsuarioDto,
+        persona: Persona? = null,
+        fabricante: Fabricante? = null,
+        encodedPassword: String,
+        roles: MutableSet<Rol>,
+    ): Usuario
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceServiceImpl.kt
@@ -2,8 +2,9 @@ package io.github.kingg22.api.vacunas.panama.modules.usuario.persistence
 
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RolDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
-import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Rol
+import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.toRol
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
 import io.github.kingg22.api.vacunas.panama.modules.usuario.repository.UsuarioRepository
 import jakarta.persistence.EntityManager
@@ -83,26 +84,26 @@ class UsuarioPersistenceServiceImpl(
      * Creates a new user entity with the given DTO and associates it with the given persona or fabricante.
      *
      * @param usuarioDto The DTO containing the user information.
-     * @param persona The persona entity to associate with the user (optional).
-     * @param fabricante The fabricante entity to associate with the user (optional).
+     * @param personaId The persona entity to associate with the user (optional).
+     * @param fabricanteId The fabricante entity to associate with the user (optional).
      * @param encodedPassword The encoded password for the user.
      * @param roles The set of roles for the user.
      * @return The created user entity.
      */
     override suspend fun createUser(
         usuarioDto: UsuarioDto,
-        persona: Persona?,
-        fabricante: Fabricante?,
+        personaId: UUID?,
+        fabricanteId: UUID?,
         encodedPassword: String,
-        roles: MutableSet<Rol>,
+        roles: Set<RolDto>,
     ): Usuario {
         var savedUsuario: Usuario? = null
         transactionTemplate.execute {
             // Find entities using entityManager.find instead of merge
-            val managedPersona = persona?.id?.let {
+            val managedPersona = personaId?.let {
                 entityManager.find(Persona::class.java, it)
             }
-            val managedFabricante = fabricante?.id?.let {
+            val managedFabricante = fabricanteId?.let {
                 entityManager.find(Fabricante::class.java, it)
             }
 
@@ -110,7 +111,7 @@ class UsuarioPersistenceServiceImpl(
                 username = usuarioDto.username,
                 clave = encodedPassword,
                 createdAt = usuarioDto.createdAt,
-                roles = roles,
+                roles = roles.map { it.toRol() }.toMutableSet(),
                 persona = managedPersona,
                 fabricante = managedFabricante,
                 id = usuarioDto.id,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/persistence/UsuarioPersistenceServiceImpl.kt
@@ -1,0 +1,77 @@
+package io.github.kingg22.api.vacunas.panama.modules.usuario.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.Usuario
+import io.github.kingg22.api.vacunas.panama.modules.usuario.repository.UsuarioRepository
+import jakarta.persistence.EntityManager
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.UUID
+
+/**
+ * Implementation of the UsuarioPersistenceService interface.
+ *
+ * This service provides operations related to the persistence of users,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class UsuarioPersistenceServiceImpl(
+    private val entityManager: EntityManager,
+    private val transactionTemplate: TransactionTemplate,
+    private val usuarioRepository: UsuarioRepository,
+) : UsuarioPersistenceService {
+
+    /**
+     * Finds a user by its ID.
+     *
+     * @param id The UUID of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    override suspend fun findUsuarioById(id: UUID) = usuarioRepository.findByIdOrNull(id)
+
+    /**
+     * Finds a user by its username.
+     *
+     * @param username The username of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    override suspend fun findByUsername(username: String?) = usuarioRepository.findByUsername(username)
+
+    /**
+     * Finds a user by its cedula, pasaporte, or correo.
+     *
+     * @param cedula The cedula of the user.
+     * @param pasaporte The pasaporte of the user.
+     * @param correo The correo of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    override suspend fun findByCedulaOrPasaporteOrCorreo(cedula: String?, pasaporte: String?, correo: String?) =
+        usuarioRepository.findByCedulaOrPasaporteOrCorreo(cedula, pasaporte, correo)
+
+    /**
+     * Finds a user by its licencia or correo.
+     *
+     * @param licencia The licencia of the user.
+     * @param correo The correo of the user.
+     * @return The user entity if found, null otherwise.
+     */
+    override suspend fun findByLicenciaOrCorreo(licencia: String?, correo: String?) =
+        usuarioRepository.findByLicenciaOrCorreo(licencia, correo)
+
+    /**
+     * Saves a user entity.
+     *
+     * @param usuario The user entity to save.
+     * @return The saved user entity.
+     */
+    override suspend fun saveUsuario(usuario: Usuario): Usuario {
+        var user: Usuario? = null
+        transactionTemplate.execute {
+            entityManager.merge(usuario)
+            user = usuarioRepository.save(usuario)
+        }
+        checkNotNull(user) { "User was not saved" }
+        return user
+    }
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/FabricanteRegistrationStrategy.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/FabricanteRegistrationStrategy.kt
@@ -1,6 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.service
 
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.dto.FabricanteDto
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.dto.toFabricante
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.toFabricanteDto
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.service.FabricanteService
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RegisterUserDto
@@ -12,7 +13,6 @@ import io.github.kingg22.api.vacunas.panama.response.ApiResponseFactory.createAp
 import io.github.kingg22.api.vacunas.panama.response.ApiResponseFactory.createContentResponse
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class FabricanteRegistrationStrategy(
@@ -55,7 +55,6 @@ class FabricanteRegistrationStrategy(
         )
     }
 
-    @Transactional
     override suspend fun create(registerUserDto: RegisterUserDto): ApiContentResponse {
         val resultValidate = validate(registerUserDto)
         return when (resultValidate) {
@@ -64,15 +63,17 @@ class FabricanteRegistrationStrategy(
             }
 
             is RegistrationSuccess -> {
-                val fabricante = resultValidate.outcome as? Fabricante
-                    ?: return createContentResponse().apply {
-                        addError(
-                            createApiErrorBuilder {
-                                withCode(ApiResponseCode.API_UPDATE_UNSUPPORTED)
-                                withMessage("No se puede crear fabricante")
-                            },
-                        )
-                    }
+                val fabricante = (
+                    resultValidate.outcome as? FabricanteDto
+                        ?: return createContentResponse().apply {
+                            addError(
+                                createApiErrorBuilder {
+                                    withCode(ApiResponseCode.API_UPDATE_UNSUPPORTED)
+                                    withMessage("No se puede crear fabricante")
+                                },
+                            )
+                        }
+                    ).toFabricante()
 
                 usuarioService.createUser(registerUserDto.usuario, fabricante = fabricante, persona = null)
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/FabricanteRegistrationStrategy.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/FabricanteRegistrationStrategy.kt
@@ -1,8 +1,6 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.service
 
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.dto.FabricanteDto
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.dto.toFabricante
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.toFabricanteDto
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.service.FabricanteService
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RegisterUserDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.service.RegistrationResult.RegistrationError
@@ -63,7 +61,7 @@ class FabricanteRegistrationStrategy(
             }
 
             is RegistrationSuccess -> {
-                val fabricante = (
+                val fabricante =
                     resultValidate.outcome as? FabricanteDto
                         ?: return createContentResponse().apply {
                             addError(
@@ -73,12 +71,11 @@ class FabricanteRegistrationStrategy(
                                 },
                             )
                         }
-                    ).toFabricante()
 
-                usuarioService.createUser(registerUserDto.usuario, fabricante = fabricante, persona = null)
+                usuarioService.createUser(registerUserDto.usuario, null, fabricante.entidad.id)
 
                 createContentResponse().apply {
-                    addData("fabricante", fabricante.toFabricanteDto())
+                    addData("fabricante", fabricante)
                 }
             }
         }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/PersonaRegistrationStrategy.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/PersonaRegistrationStrategy.kt
@@ -1,6 +1,8 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.service
 
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
+import io.github.kingg22.api.vacunas.panama.modules.persona.entity.fromPersonaModel
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.toPersonaDto
 import io.github.kingg22.api.vacunas.panama.modules.persona.service.PersonaService
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RegisterUserDto
@@ -13,7 +15,6 @@ import io.github.kingg22.api.vacunas.panama.response.ApiResponseFactory.createCo
 import io.github.kingg22.api.vacunas.panama.util.logger
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class PersonaRegistrationStrategy(
@@ -57,7 +58,6 @@ class PersonaRegistrationStrategy(
         )
     }
 
-    @Transactional
     override suspend fun create(registerUserDto: RegisterUserDto): ApiContentResponse {
         val resultValidate = validate(registerUserDto)
         return when (resultValidate) {
@@ -66,8 +66,8 @@ class PersonaRegistrationStrategy(
             }
 
             is RegistrationSuccess -> {
-                val persona = (
-                    resultValidate.outcome as? Persona
+                val persona = Persona.fromPersonaModel(
+                    resultValidate.outcome as? PersonaModel
                         ?: return createContentResponse().apply {
                             addError(
                                 createApiErrorBuilder {
@@ -75,8 +75,8 @@ class PersonaRegistrationStrategy(
                                     withMessage("No se puede crear persona")
                                 },
                             )
-                        }
-                    )
+                        },
+                )
                 log.debug("Persona validated: {}", persona)
                 log.debug("Persona ID: {}", persona.id)
 

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/PersonaRegistrationStrategy.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/PersonaRegistrationStrategy.kt
@@ -80,7 +80,7 @@ class PersonaRegistrationStrategy(
                 log.debug("Persona validated: {}", persona)
                 log.debug("Persona ID: {}", persona.id)
 
-                usuarioService.createUser(registerUserDto.usuario, persona = persona, fabricante = null)
+                usuarioService.createUser(registerUserDto.usuario, persona.id, null)
 
                 createContentResponse().apply {
                     addData("persona", persona.toPersonaDto())

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/UsuarioService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/UsuarioService.kt
@@ -1,7 +1,5 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.service
 
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
-import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RegisterUserDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RestoreDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
@@ -57,7 +55,15 @@ interface UsuarioService {
      */
     suspend fun createUser(registerUserDto: RegisterUserDto, authentication: Authentication? = null): ApiContentResponse
 
-    suspend fun createUser(usuarioDto: UsuarioDto, persona: Persona?, fabricante: Fabricante?)
+    /**
+     * Registers a new user.
+     * _This is an internal function to [RegistrationStrategy]._
+     *
+     * @param usuarioDto Usuario DTO containing the user information.
+     * @param personaId Optional if the user is linked to a persona.
+     * @param fabricanteId Optional if the user is linked to fabricante.
+     */
+    suspend fun createUser(usuarioDto: UsuarioDto, personaId: UUID?, fabricanteId: UUID?)
 
     /**
      * Changes the password of a user using the provided restore DTO.

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/UsuarioServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/usuario/service/UsuarioServiceImpl.kt
@@ -1,9 +1,7 @@
 package io.github.kingg22.api.vacunas.panama.modules.usuario.service
 
-import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.Fabricante
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.entity.toFabricanteDto
 import io.github.kingg22.api.vacunas.panama.modules.fabricante.service.FabricanteService
-import io.github.kingg22.api.vacunas.panama.modules.persona.entity.Persona
 import io.github.kingg22.api.vacunas.panama.modules.persona.entity.toPersonaDto
 import io.github.kingg22.api.vacunas.panama.modules.persona.service.PersonaService
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RegisterUserDto
@@ -11,7 +9,6 @@ import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RestoreDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RolDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.RolesEnum
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.UsuarioDto
-import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.toRol
 import io.github.kingg22.api.vacunas.panama.modules.usuario.dto.toUsuario
 import io.github.kingg22.api.vacunas.panama.modules.usuario.entity.toUsuarioDto
 import io.github.kingg22.api.vacunas.panama.modules.usuario.persistence.UsuarioPersistenceService
@@ -138,19 +135,19 @@ class UsuarioServiceImpl(
         return response
     }
 
-    override suspend fun createUser(usuarioDto: UsuarioDto, persona: Persona?, fabricante: Fabricante?) {
-        val roles = rolPermisoService.convertToExistRol(usuarioDto.roles).map { it.toRol() }.toMutableSet()
-        val encodedPassword = passwordEncoder.encode(usuarioDto.password)
+    override suspend fun createUser(usuarioDto: UsuarioDto, personaId: UUID?, fabricanteId: UUID?) {
+        val roles = rolPermisoService.convertToExistRol(usuarioDto.roles)
+        val encodedPassword: String = passwordEncoder.encode(usuarioDto.password)
 
-        val usuario = usuarioPersistenceService.createUser(
+        usuarioPersistenceService.createUser(
             usuarioDto = usuarioDto,
-            persona = persona,
-            fabricante = fabricante,
+            personaId = personaId,
+            fabricanteId = fabricanteId,
             encodedPassword = encodedPassword,
             roles = roles,
-        )
-
-        log.trace("User created: {}", usuario)
+        ).also {
+            log.trace("User created: {}", it)
+        }
     }
 
     override suspend fun changePassword(restoreDto: RestoreDto): ApiContentResponse {

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/domain/DosisModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/domain/DosisModel.kt
@@ -1,0 +1,55 @@
+package io.github.kingg22.api.vacunas.panama.modules.vacuna.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.doctor.domain.DoctorModel
+import io.github.kingg22.api.vacunas.panama.modules.paciente.domain.PacienteModel
+import io.github.kingg22.api.vacunas.panama.modules.persona.domain.PersonaModel
+import io.github.kingg22.api.vacunas.panama.modules.sede.domain.SedeModel
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Domain model representing a vaccine dose.
+ */
+data class DosisModel(
+    val id: UUID? = null,
+    val paciente: PacienteModel,
+    val numeroDosis: String,
+    val vacuna: VacunaModel,
+    val sede: SedeModel,
+    val lote: String? = null,
+    val doctor: DoctorModel? = null,
+    val fechaAplicacion: LocalDateTime,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+) {
+    /**
+     * @param pacienteId The UUID of the patient.
+     * @param vacunaId The UUID of the vaccine.
+     * @param sedeId The UUID of the sede.
+     * @param numeroDosis The number of the dose.
+     * @param lote The lot of the vaccine (optional).
+     * @param doctorId The UUID of the doctor (optional).
+     * @param fechaAplicacion The date of application (optional).
+     */
+    constructor(
+        pacienteId: UUID,
+        vacunaId: UUID,
+        sedeId: UUID,
+        numeroDosis: String,
+        lote: String? = null,
+        doctorId: UUID? = null,
+        fechaAplicacion: LocalDateTime? = null,
+    ) : this(
+        id = null,
+        PacienteModel(PersonaModel(pacienteId), createdAt = LocalDateTime.now(ZoneOffset.UTC)),
+        numeroDosis,
+        VacunaModel(vacunaId, "", createdAt = LocalDateTime.now(ZoneOffset.UTC)),
+        SedeModel(sedeId, "", createdAt = LocalDateTime.now()),
+        lote,
+        doctorId?.let { DoctorModel(it, PersonaModel(), createdAt = LocalDateTime.now(ZoneOffset.UTC)) },
+        fechaAplicacion ?: LocalDateTime.now(ZoneOffset.UTC),
+        LocalDateTime.now(ZoneOffset.UTC),
+        null,
+    )
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/domain/VacunaModel.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/domain/VacunaModel.kt
@@ -1,0 +1,19 @@
+package io.github.kingg22.api.vacunas.panama.modules.vacuna.domain
+
+import io.github.kingg22.api.vacunas.panama.modules.fabricante.domain.FabricanteModel
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Domain model representing a vaccine in the system.
+ * This is a pure Kotlin data class with immutable properties.
+ */
+data class VacunaModel(
+    val id: UUID? = null,
+    val nombre: String,
+    val descripcion: String? = null,
+    val edadMinimaDias: Short? = null,
+    val fabricante: FabricanteModel? = null,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/dto/DosisDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/dto/DosisDto.kt
@@ -40,8 +40,8 @@ data class DosisDto(
     @param:PastOrPresent
     val createdAt: LocalDateTime,
 
-    @field:JsonProperty(value = "updated_at")
-    @param:JsonProperty(value = "updated_at")
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @field:PastOrPresent
     @param:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/dto/VacunaDto.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/dto/VacunaDto.kt
@@ -31,8 +31,8 @@ data class VacunaDto(
     @field:PastOrPresent
     val createdAt: LocalDateTime? = null,
 
-    @param:JsonProperty(value = "updated_at")
-    @field:JsonProperty(value = "updated_at")
+    @param:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
+    @field:JsonProperty(value = "updated_at", access = JsonProperty.Access.READ_ONLY)
     @param:PastOrPresent
     @field:PastOrPresent
     val updatedAt: LocalDateTime? = null,

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceService.kt
@@ -1,6 +1,8 @@
 package io.github.kingg22.api.vacunas.panama.modules.vacuna.persistence
 
+import io.github.kingg22.api.vacunas.panama.modules.paciente.domain.PacienteModel
 import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.domain.DosisModel
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.dto.VacunaFabricanteDto
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Dosis
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Vacuna
@@ -33,12 +35,13 @@ interface VacunaPersistenceService {
     suspend fun findTopDosisByPacienteAndVacuna(paciente: Paciente, vacuna: Vacuna): Dosis?
 
     /**
-     * Saves a new dose entity.
+     * Finds the most recent dose for a patient and vaccine.
      *
-     * @param dosis The dose entity to save.
-     * @return The saved dose entity.
+     * @param paciente The patient model
+     * @param vacuna The vaccine entity.
+     * @return The most recent dose entity if found, null otherwise.
      */
-    suspend fun saveDosis(dosis: Dosis): Dosis
+    suspend fun findTopDosisByPacienteAndVacuna(paciente: PacienteModel, vacuna: Vacuna): Dosis?
 
     /**
      * Finds all vaccines with their manufacturers.
@@ -55,4 +58,12 @@ interface VacunaPersistenceService {
      * @return A list of dose entities.
      */
     suspend fun findAllDosisByPacienteIdAndVacunaId(idPaciente: UUID, idVacuna: UUID): List<Dosis>
+
+    /**
+     * Creates and saves a new dose entity.
+     *
+     * @param dosisModel The dosis model
+     * @return The saved dose entity.
+     */
+    suspend fun createAndSaveDosis(dosisModel: DosisModel): Dosis
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceService.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceService.kt
@@ -1,0 +1,58 @@
+package io.github.kingg22.api.vacunas.panama.modules.vacuna.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.dto.VacunaFabricanteDto
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Dosis
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Vacuna
+import java.util.UUID
+
+/**
+ * Persistence service interface for managing vaccines and doses.
+ *
+ * This service provides operations related to the persistence of vaccines and doses,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+interface VacunaPersistenceService {
+
+    /**
+     * Finds a vaccine by its ID.
+     *
+     * @param id The UUID of the vaccine.
+     * @return The vaccine entity if found, null otherwise.
+     */
+    suspend fun findVacunaById(id: UUID): Vacuna?
+
+    /**
+     * Finds the most recent dose for a patient and vaccine.
+     *
+     * @param paciente The patient entity.
+     * @param vacuna The vaccine entity.
+     * @return The most recent dose entity if found, null otherwise.
+     */
+    suspend fun findTopDosisByPacienteAndVacuna(paciente: Paciente, vacuna: Vacuna): Dosis?
+
+    /**
+     * Saves a new dose entity.
+     *
+     * @param dosis The dose entity to save.
+     * @return The saved dose entity.
+     */
+    suspend fun saveDosis(dosis: Dosis): Dosis
+
+    /**
+     * Finds all vaccines with their manufacturers.
+     *
+     * @return A list of DTOs containing vaccine manufacturer details.
+     */
+    suspend fun findAllVacunasWithFabricantes(): List<VacunaFabricanteDto>
+
+    /**
+     * Finds all doses for a patient and vaccine.
+     *
+     * @param idPaciente The UUID of the patient.
+     * @param idVacuna The UUID of the vaccine.
+     * @return A list of dose entities.
+     */
+    suspend fun findAllDosisByPacienteIdAndVacunaId(idPaciente: UUID, idVacuna: UUID): List<Dosis>
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceServiceImpl.kt
@@ -1,0 +1,79 @@
+package io.github.kingg22.api.vacunas.panama.modules.vacuna.persistence
+
+import io.github.kingg22.api.vacunas.panama.modules.paciente.entity.Paciente
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Dosis
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Vacuna
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.repository.DosisRepository
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.repository.VacunaRepository
+import jakarta.persistence.EntityManager
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.UUID
+
+/**
+ * Implementation of the VacunaPersistenceService interface.
+ *
+ * This service provides operations related to the persistence of vaccines and doses,
+ * acting as an intermediate layer between the repositories and the service layer.
+ * It encapsulates all JPA-related operations.
+ */
+@Service
+class VacunaPersistenceServiceImpl(
+    private val entityManager: EntityManager,
+    private val transactionTemplate: TransactionTemplate,
+    private val vacunaRepository: VacunaRepository,
+    private val dosisRepository: DosisRepository,
+) : VacunaPersistenceService {
+
+    /**
+     * Finds a vaccine by its ID.
+     *
+     * @param id The UUID of the vaccine.
+     * @return The vaccine entity if found, null otherwise.
+     */
+    override suspend fun findVacunaById(id: UUID) = vacunaRepository.findByIdOrNull(id)
+
+    /**
+     * Finds the most recent dose for a patient and vaccine.
+     *
+     * @param paciente The patient entity.
+     * @param vacuna The vaccine entity.
+     * @return The most recent dose entity if found, null otherwise.
+     */
+    override suspend fun findTopDosisByPacienteAndVacuna(paciente: Paciente, vacuna: Vacuna) =
+        dosisRepository.findTopByPacienteAndVacunaOrderByCreatedAtDesc(paciente, vacuna)
+
+    /**
+     * Saves a new dose entity.
+     *
+     * @param dosis The dose entity to save.
+     * @return The saved dose entity.
+     */
+    override suspend fun saveDosis(dosis: Dosis): Dosis {
+        var savedDosis: Dosis? = null
+        transactionTemplate.execute {
+            entityManager.persist(dosis)
+            savedDosis = dosis
+        }
+        checkNotNull(savedDosis) { "Dosis not saved" }
+        return savedDosis
+    }
+
+    /**
+     * Finds all vaccines with their manufacturers.
+     *
+     * @return A list of DTOs containing vaccine manufacturer details.
+     */
+    override suspend fun findAllVacunasWithFabricantes() = vacunaRepository.findAllIdAndNombreAndFabricante()
+
+    /**
+     * Finds all doses for a patient and vaccine.
+     *
+     * @param idPaciente The UUID of the patient.
+     * @param idVacuna The UUID of the vaccine.
+     * @return A list of dose entities.
+     */
+    override suspend fun findAllDosisByPacienteIdAndVacunaId(idPaciente: UUID, idVacuna: UUID) =
+        dosisRepository.findAllByPaciente_IdAndVacuna_IdOrderByCreatedAtDesc(idPaciente, idVacuna)
+}

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/persistence/VacunaPersistenceServiceImpl.kt
@@ -116,7 +116,9 @@ class VacunaPersistenceServiceImpl(
             entityManager.persist(dosis)
             savedDosis = dosis
         }
-        checkNotNull(savedDosis) { "Dosis not saved" }
+        checkNotNull(savedDosis) {
+            "Dosis not saved for paciente=$pacienteId, sede=$sedeId, numero dosis=$numeroDosis, fecha aplicación=$fechaAplicacion, lote=$lote, doctor=$doctorId"
+        }
         return savedDosis
     }
 }

--- a/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/service/VacunaServiceImpl.kt
+++ b/src/main/kotlin/io/github/kingg22/api/vacunas/panama/modules/vacuna/service/VacunaServiceImpl.kt
@@ -1,12 +1,11 @@
 package io.github.kingg22.api.vacunas.panama.modules.vacuna.service
 
 import io.github.kingg22.api.vacunas.panama.configuration.CacheDuration
-import io.github.kingg22.api.vacunas.panama.modules.doctor.dto.toDoctor
 import io.github.kingg22.api.vacunas.panama.modules.doctor.service.DoctorService
 import io.github.kingg22.api.vacunas.panama.modules.paciente.service.PacienteService
 import io.github.kingg22.api.vacunas.panama.modules.sede.service.SedeService
+import io.github.kingg22.api.vacunas.panama.modules.vacuna.domain.DosisModel
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.dto.InsertDosisDto
-import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.Dosis
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.entity.toDosisDto
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.extensions.getNumeroDosisAsEnum
 import io.github.kingg22.api.vacunas.panama.modules.vacuna.extensions.toListDosisDto
@@ -20,8 +19,6 @@ import io.github.kingg22.api.vacunas.panama.util.logger
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
-import java.time.ZoneOffset.UTC
 import java.util.UUID
 
 @Service
@@ -94,16 +91,15 @@ class VacunaServiceImpl(
         }) { log.debug("El paciente no tiene dosis previas") }
         contentResponse.build().returnIfErrors()?.let { return it }
 
-        val dosis = vacunaPersistenceService.saveDosis(
-            Dosis(
-                paciente = paciente,
+        val dosis = vacunaPersistenceService.createAndSaveDosis(
+            DosisModel(
+                pacienteId = insertDosisDto.pacienteId,
+                vacunaId = insertDosisDto.vacunaId,
+                sedeId = insertDosisDto.sedeId,
                 numeroDosis = insertDosisDto.numeroDosis.value,
-                vacuna = vacuna,
-                sede = sede,
                 lote = insertDosisDto.lote,
-                doctor = doctor?.toDoctor(),
-                fechaAplicacion = insertDosisDto.fechaAplicacion ?: LocalDateTime.now(UTC),
-                createdAt = LocalDateTime.now(UTC),
+                doctorId = insertDosisDto.doctorId,
+                fechaAplicacion = insertDosisDto.fechaAplicacion,
             ),
         )
         contentResponse.withData("dosis", dosis.toDosisDto())

--- a/src/test/kotlin/io/github/kingg22/api/vacunas/panama/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/io/github/kingg22/api/vacunas/panama/TestcontainersConfiguration.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 @TestConfiguration(proxyBeanMethods = false)
@@ -16,4 +17,9 @@ class TestcontainersConfiguration {
     @ServiceConnection(name = "redis")
     fun redisContainer(): GenericContainer<*> =
         GenericContainer(DockerImageName.parse("redis:latest")).withExposedPorts(6379)
+
+    @Bean
+    @Rule
+    @ServiceConnection
+    fun postgresContainer(): PostgreSQLContainer<*> = PostgreSQLContainer(DockerImageName.parse("postgres:17-alpine"))
 }

--- a/src/test/kotlin/io/github/kingg22/api/vacunas/panama/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/io/github/kingg22/api/vacunas/panama/TestcontainersConfiguration.kt
@@ -6,7 +6,6 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 @TestConfiguration(proxyBeanMethods = false)
@@ -17,7 +16,4 @@ class TestcontainersConfiguration {
     @ServiceConnection(name = "redis")
     fun redisContainer(): GenericContainer<*> =
         GenericContainer(DockerImageName.parse("redis:latest")).withExposedPorts(6379)
-
-    @Rule
-    fun postgresContainer(): PostgreSQLContainer<*> = PostgreSQLContainer("postgres:17-alpine")
 }

--- a/src/test/kotlin/io/github/kingg22/api/vacunas/panama/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/io/github/kingg22/api/vacunas/panama/TestcontainersConfiguration.kt
@@ -1,17 +1,23 @@
 package io.github.kingg22.api.vacunas.panama
 
+import org.junit.Rule
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 @TestConfiguration(proxyBeanMethods = false)
 @ActiveProfiles("test")
 class TestcontainersConfiguration {
     @Bean
+    @Rule
     @ServiceConnection(name = "redis")
     fun redisContainer(): GenericContainer<*> =
         GenericContainer(DockerImageName.parse("redis:latest")).withExposedPorts(6379)
+
+    @Rule
+    fun postgresContainer(): PostgreSQLContainer<*> = PostgreSQLContainer("postgres:17-alpine")
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -5,9 +5,9 @@ spring.main.lazy-initialization=true
 # Liquibase
 spring.liquibase.contexts=test
 # Datasource DB
-spring.datasource.url=jdbc:tc:postgresql:17-alpine:///vacunas
-spring.datasource.username=sa
-spring.datasource.password=password
+#spring.datasource.url=jdbc:tc:postgresql:17-alpine:///vacunas
+#spring.datasource.username=sa
+#spring.datasource.password=password
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true


### PR DESCRIPTION
This PR is part of clean architecture refactor [TASK-88] and prepare for framework migration [TASK-95]. Most of changes of this PR have been created using JetBrains Junie, these changes need to be monitored.

## Resumen por Sourcery

Refactorización de la capa de datos para introducir una capa de servicio de persistencia, desacoplando las interacciones de entidades y mejorando la separación arquitectónica de responsabilidades.

Mejoras:
- Se introdujeron interfaces e implementaciones de servicio de persistencia para varios módulos.
- Se eliminaron las llamadas directas al repositorio de las implementaciones de servicio.
- Se agregaron modelos de dominio para representar las entidades centrales.

Tareas:
- Se eliminaron las anotaciones transaccionales de los métodos de servicio.
- Se actualizaron las firmas de los métodos para usar los nuevos servicios de persistencia.
- Se agregó un manejo de errores más robusto en la capa de persistencia.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor data layer to introduce a persistence service layer, decoupling entity interactions and improving architectural separation of concerns

Enhancements:
- Introduced persistence service interfaces and implementations for various modules
- Removed direct repository calls from service implementations
- Added domain models to represent core entities

Chores:
- Removed transactional annotations from service methods
- Updated method signatures to use new persistence services
- Added more robust error handling in persistence layer

</details>